### PR TITLE
Make sure GPU ids are integers

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -85,7 +85,7 @@ parser.add_argument("--slide_file_path", type=str, default=None)
 parser.add_argument("--patch_file_path", type=str, default=None)
 parser.add_argument("--save_dir", type=str, default=None)
 parser.add_argument("--batch_size", type=int, default=256)
-parser.add_argument("--gpus", type=list, default=[0])
+parser.add_argument("--gpus", nargs="+", type=int, default=[0])
 args = parser.parse_args()
 
 assert torch.cuda.is_available(), "no cuda available"


### PR DESCRIPTION
This PR fixes the statement defining the "--gpus" cmdline argument.  

List-valued arguments are supposed to be created using the "nargs" parameter to argparse.add_argument(), with the "type" parameter defining the type of the list elements.  The original code caused "--gpu" to produce a list of strings for the gpu ids, but the gpu ids need to be passed to pytorch as integers.

I noticed this when I tried unsuccessfully to run extract_features.py with the arguments "--gpus 3", because the other gpus on the server I was working on were in use.