### PR TITLE
feat: add clustering_benchmark CLI for model evaluation via clustering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Pin uv image as a named stage to avoid fuse-overlayfs issues with inline COPY --from
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
 # Stage 1: Builder
 FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04 AS builder
 
@@ -21,7 +24,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
   && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/
 
 ARG BACKEND=torch-gpu
 ENV BACKEND=$BACKEND

--- a/README-commands.md
+++ b/README-commands.md
@@ -17,6 +17,7 @@ slides, and generating feature embeddings with pathology foundation models.
 * `filter_features` - filter features using a classifier model
 * `merge_annotation_features` - merge tile features with annotations from a BMP file.
 * `linear_probe_benchmark` - benchmark a linear probe classifier on features extracted from a slide
+* `clustering_benchmark` - evaluate feature quality by clustering tile-level embeddings and comparing with annotation labels
 * `save_model` - download and save a foundation model locally
 * `convert` - convert whole-slide images to pyramidal TIFF format (single file or batch)
 
@@ -369,6 +370,62 @@ cache_tiles \
 ```
 
 *This takes about ten seconds for an example slide.*
+
+### `clustering_benchmark`
+
+`clustering_benchmark` evaluates the quality of tile-level feature embeddings by clustering
+them and comparing the resulting assignments to annotation labels.  It is designed to work
+with the GeoParquet file produced by `merge_annotation_features`.
+
+Outputs three files:
+
+| Output | Default filename | Contents |
+|---|---|---|
+| Metrics CSV | `clustering_metrics.csv` | Per-algorithm NMI, ARI, purity at tile and slide level |
+| Summary JSON | `clustering_results.json` | All scalar metrics as a nested dict |
+| UMAP PNG | `umap.png` | UMAP scatter-plot grid (cluster coloring vs annotation coloring for each algorithm) |
+
+#### Example
+
+```bash
+clustering_benchmark \
+    features_annotation_parquet_path=features_with_annotations.parquet \
+    output_metrics_csv=metrics.csv \
+    output_summary_json=results.json \
+    output_umap_png=umap.png \
+    'algorithms=["kmeans","hierarchical","dbscan"]' \
+    n_clusters=3 \
+    multiclass=true
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `features_annotation_parquet_path` | required | GeoParquet from `merge_annotation_features` (must contain `slide_id`, `annotation`, `overlap_area`, `tile_area`, and `feature_*` columns). |
+| `output_metrics_csv` | `clustering_metrics.csv` | Path for per-algorithm metrics table. |
+| `output_summary_json` | `clustering_results.json` | Path for nested-dict metrics JSON. |
+| `output_umap_png` | `umap.png` | Path for UMAP scatter-plot grid. |
+| `annotation_percent_filter_threshold` | `0.50` | Minimum overlap fraction to include a tile. |
+| `positive_annotation_label` | `2` | Annotation value treated as the positive class in binary mode. |
+| `multiclass` | `false` | Use all non-zero annotation values as class labels (background tiles excluded). |
+| `algorithms` | `["kmeans","hierarchical"]` | Clustering algorithms to run. Supported: `"kmeans"`, `"hierarchical"`, `"dbscan"`. |
+| `n_clusters` | `2` | Number of clusters for kmeans and hierarchical. |
+| `dbscan_eps` | `0.5` | DBSCAN neighbourhood radius. |
+| `dbscan_min_samples` | `5` | DBSCAN minimum samples per core point. |
+| `umap_n_neighbors` | `15` | UMAP `n_neighbors`. |
+| `umap_min_dist` | `0.1` | UMAP `min_dist`. |
+| `umap_n_components` | `2` | UMAP output dimensionality: `2` for 2-D plots, `3` for 3-D scatter plots. |
+| `umap_subsample` | `10000` | Max tiles used for UMAP projection (random subsample for speed). Use `0` to disable. |
+| `random_state` | `42` | Random seed. |
+
+UMAP requires the optional `umap-learn` package:
+
+```bash
+uv sync --extra umap
+# or
+pip install umap-learn
+```
 
 ### `save_model`
 

--- a/mussel/cli/clustering_benchmark.py
+++ b/mussel/cli/clustering_benchmark.py
@@ -1,0 +1,429 @@
+import json
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import hydra
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from hydra.conf import HelpConf, HydraConf
+from hydra.core.config_store import ConfigStore
+from omegaconf import MISSING
+from sklearn.cluster import DBSCAN, AgglomerativeClustering, KMeans
+from sklearn.metrics import (
+    adjusted_rand_score,
+    normalized_mutual_info_score,
+    silhouette_score,
+)
+from sklearn.preprocessing import StandardScaler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ClusteringBenchmarkConfig:
+    """
+    features_annotation_parquet_path (str): Path to the GeoParquet file produced by
+        merge_annotation_features (must contain slide_id, annotation, overlap_area,
+        tile_area, and feature_* columns).
+    output_metrics_csv (str): Per-algorithm metrics table (CSV).
+    output_summary_json (str): All scalar metrics as a nested dict (JSON).
+    output_umap_png (str): UMAP scatter-plot grid (PNG); one figure with columns
+        [cluster coloring, annotation coloring] for each algorithm row.
+    annotation_percent_filter_threshold (float): Min overlap fraction to include a tile
+        (default 0.50).
+    positive_annotation_label (int): Annotation value treated as the positive class
+        in binary mode (default 2).
+    multiclass (bool): If True, use all non-zero annotation values as class labels.
+        Background (annotation == 0) tiles are excluded.
+    algorithms (List[str]): Clustering algorithms to run.  Supported: "kmeans",
+        "hierarchical", "dbscan".  Default: ["kmeans", "hierarchical"].
+    n_clusters (int): Number of clusters for kmeans and hierarchical (default 2).
+    dbscan_eps (float): DBSCAN neighbourhood radius (default 0.5).
+    dbscan_min_samples (int): DBSCAN minimum samples per core point (default 5).
+    umap_n_neighbors (int): UMAP n_neighbors (default 15).
+    umap_min_dist (float): UMAP min_dist (default 0.1).
+    umap_n_components (int): UMAP output dimensionality — must be 2 for plotting
+        (default 2).
+    umap_subsample (int): Maximum number of tiles used for UMAP projection (random
+        subsample for speed; default 10000). Use 0 to disable subsampling.
+    random_state (int): Random seed (default 42).
+    """
+
+    features_annotation_parquet_path: str = MISSING
+    output_metrics_csv: str = "clustering_metrics.csv"
+    output_summary_json: str = "clustering_results.json"
+    output_umap_png: str = "umap.png"
+    annotation_percent_filter_threshold: float = 0.50
+    positive_annotation_label: int = 2
+    multiclass: bool = False
+    algorithms: List[str] = field(default_factory=lambda: ["kmeans", "hierarchical"])
+    n_clusters: int = 2
+    dbscan_eps: float = 0.5
+    dbscan_min_samples: int = 5
+    umap_n_neighbors: int = 15
+    umap_min_dist: float = 0.1
+    umap_n_components: int = 2
+    umap_subsample: int = 10_000
+    random_state: int = 42
+
+
+desc_doc = """== ${hydra.help.app_name} ==
+Evaluate feature quality by clustering tile-level embeddings and comparing the
+resulting cluster assignments to annotation labels.  Produces supervised external
+metrics (NMI, ARI, purity) at both tile and slide level, plus UMAP scatter plots.
+"""
+
+parameter_doc = f"""
+== Available Parameters ==
+{ClusteringBenchmarkConfig.__doc__}
+"""
+
+cs = ConfigStore.instance()
+cs.store(
+    group="hydra",
+    name="config",
+    node=HydraConf(help=HelpConf(header=desc_doc, footer=parameter_doc)),
+    provider="hydra",
+)
+cs.store(name="clustering_benchmark_config", node=ClusteringBenchmarkConfig)
+
+
+# ── Metric helpers ─────────────────────────────────────────────────────────────
+
+
+def _cluster_purity(labels_true: np.ndarray, labels_pred: np.ndarray) -> float:
+    """Fraction of tiles matching the majority annotation in their assigned cluster.
+
+    Tiles labelled -1 by DBSCAN (noise) are excluded from the calculation.
+    Returns NaN when no tiles remain after exclusion.
+    """
+    mask = labels_pred != -1
+    if not mask.any():
+        return float("nan")
+    lt = labels_true[mask]
+    lp = labels_pred[mask]
+    total = len(lt)
+    correct = 0
+    for cluster_id in np.unique(lp):
+        in_cluster = lt[lp == cluster_id]
+        correct += int(np.bincount(in_cluster).max())
+    return correct / total
+
+
+def _compute_cluster_metrics(
+    labels_true: np.ndarray,
+    labels_pred: np.ndarray,
+    X_scaled: np.ndarray,
+    split_name: str,
+    algo_name: str,
+    random_state: int = 42,
+) -> dict:
+    """Compute NMI, ARI, purity, and silhouette for one (algorithm, split) pair.
+
+    DBSCAN noise points (label == -1) are excluded from all metrics.
+    Silhouette is skipped when fewer than 2 distinct non-noise clusters are found.
+    """
+    noise_mask = labels_pred != -1
+    lt_clean = labels_true[noise_mask]
+    lp_clean = labels_pred[noise_mask]
+
+    if len(lp_clean) == 0:
+        logger.warning("[%s/%s] all tiles are noise — metrics set to NaN", algo_name, split_name)
+        return {
+            "nmi": float("nan"),
+            "ari": float("nan"),
+            "purity": float("nan"),
+            "silhouette": float("nan"),
+            "n_noise": int((~noise_mask).sum()),
+            "n_clusters_found": 0,
+        }
+
+    n_clusters_found = len(np.unique(lp_clean))
+    nmi = float(normalized_mutual_info_score(lt_clean, lp_clean, average_method="arithmetic"))
+    ari = float(adjusted_rand_score(lt_clean, lp_clean))
+    purity = _cluster_purity(labels_true, labels_pred)
+
+    sil: Optional[float] = None
+    if n_clusters_found >= 2 and len(lp_clean) >= n_clusters_found + 1:
+        try:
+            sil = float(silhouette_score(X_scaled[noise_mask], lp_clean, sample_size=min(5000, len(lp_clean)), random_state=random_state))
+        except Exception as exc:
+            logger.warning("[%s/%s] silhouette failed: %s", algo_name, split_name, exc)
+
+    metrics = {
+        "nmi": nmi,
+        "ari": ari,
+        "purity": purity,
+        "silhouette": sil if sil is not None else float("nan"),
+        "n_noise": int((~noise_mask).sum()),
+        "n_clusters_found": n_clusters_found,
+    }
+    logger.info(
+        "[%s/%s]  NMI=%.4f  ARI=%.4f  Purity=%.4f  Silhouette=%s  clusters=%d  noise=%d",
+        algo_name,
+        split_name,
+        nmi,
+        ari,
+        purity,
+        f"{sil:.4f}" if sil is not None else "n/a",
+        n_clusters_found,
+        metrics["n_noise"],
+    )
+    return metrics
+
+
+def _slide_level_metrics(
+    df: pd.DataFrame,
+    labels_pred: np.ndarray,
+    algo_name: str,
+) -> dict:
+    """Majority-vote cluster label per slide → NMI, ARI, purity vs slide annotation.
+
+    Slides where all tiles are DBSCAN noise (label == -1) are excluded.
+    """
+    tmp = df[["slide_id", "y"]].copy()
+    tmp["cluster"] = labels_pred
+
+    def _majority_label(x):
+        clean = x[x != -1].astype(int)
+        if len(clean) == 0:
+            return -1
+        return int(np.argmax(np.bincount(clean)))
+
+    slide_df = (
+        tmp.groupby("slide_id")
+        .agg(y=("y", _majority_label), cluster=("cluster", _majority_label))
+        .reset_index()
+    )
+    slide_df = slide_df[slide_df["cluster"] != -1]
+
+    if len(slide_df) == 0 or slide_df["y"].nunique() < 2:
+        logger.warning("[%s/slide] not enough distinct classes — slide metrics skipped", algo_name)
+        return {}
+
+    lt_s = slide_df["y"].values
+    lp_s = slide_df["cluster"].values
+    metrics = {
+        "slide_nmi": float(normalized_mutual_info_score(lt_s, lp_s, average_method="arithmetic")),
+        "slide_ari": float(adjusted_rand_score(lt_s, lp_s)),
+        "slide_purity": _cluster_purity(lt_s, lp_s),
+    }
+    logger.info(
+        "[%s/slide]  n=%d  NMI=%.4f  ARI=%.4f  Purity=%.4f",
+        algo_name,
+        len(slide_df),
+        metrics["slide_nmi"],
+        metrics["slide_ari"],
+        metrics["slide_purity"],
+    )
+    return metrics
+
+
+# ── Clustering helpers ─────────────────────────────────────────────────────────
+
+
+def _fit_predict(algo_name: str, X: np.ndarray, cfg: ClusteringBenchmarkConfig) -> np.ndarray:
+    """Fit a clustering algorithm and return integer cluster labels."""
+    if algo_name == "kmeans":
+        model = KMeans(n_clusters=cfg.n_clusters, random_state=cfg.random_state, n_init=10)
+    elif algo_name == "hierarchical":
+        model = AgglomerativeClustering(n_clusters=cfg.n_clusters)
+    elif algo_name == "dbscan":
+        model = DBSCAN(eps=cfg.dbscan_eps, min_samples=cfg.dbscan_min_samples)
+    else:
+        raise ValueError(f"Unknown algorithm '{algo_name}'. Supported: kmeans, hierarchical, dbscan.")
+    return model.fit_predict(X)
+
+
+# ── Plot helpers ───────────────────────────────────────────────────────────────
+
+
+def _plot_umap(
+    embedding: np.ndarray,
+    subsample_idx: np.ndarray,
+    labels_by_algo: dict,
+    true_labels: np.ndarray,
+    output_path: str,
+    algo_names: List[str],
+) -> None:
+    """UMAP scatter-plot grid.
+
+    Rows = algorithms, columns = [cluster coloring, annotation coloring].
+    """
+    n_algos = len(algo_names)
+    fig, axes = plt.subplots(n_algos, 2, figsize=(10, 4 * n_algos), squeeze=False)
+
+    for row, algo in enumerate(algo_names):
+        cluster_labels = labels_by_algo[algo][subsample_idx]
+        annot_labels = true_labels[subsample_idx]
+
+        # Left: cluster coloring
+        ax_cl = axes[row][0]
+        scatter = ax_cl.scatter(
+            embedding[:, 0], embedding[:, 1],
+            c=cluster_labels, cmap="tab20", s=2, alpha=0.5, rasterized=True,
+        )
+        plt.colorbar(scatter, ax=ax_cl, label="Cluster")
+        ax_cl.set_title(f"{algo} — clusters")
+        ax_cl.set_xlabel("UMAP-1")
+        ax_cl.set_ylabel("UMAP-2")
+
+        # Right: annotation coloring
+        ax_an = axes[row][1]
+        scatter2 = ax_an.scatter(
+            embedding[:, 0], embedding[:, 1],
+            c=annot_labels, cmap="tab10", s=2, alpha=0.5, rasterized=True,
+        )
+        plt.colorbar(scatter2, ax=ax_an, label="Annotation")
+        ax_an.set_title(f"{algo} — annotation")
+        ax_an.set_xlabel("UMAP-1")
+        ax_an.set_ylabel("UMAP-2")
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved UMAP plot → %s", output_path)
+
+
+def _sanitize_for_json(obj):
+    """Recursively replace float NaN/Inf with None so json.dump produces valid JSON."""
+    if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+        return None
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(v) for v in obj]
+    return obj
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+@hydra.main(
+    version_base=None, config_path=".", config_name="clustering_benchmark_config"
+)
+def main(cfg: ClusteringBenchmarkConfig):
+    """Benchmark clustering algorithms on extracted WSI tile features."""
+    import pyarrow.parquet as pq
+
+    _schema_names = pq.read_schema(cfg.features_annotation_parquet_path).names
+    _cols = [c for c in _schema_names if c != "geometry"]
+    df = pd.read_parquet(cfg.features_annotation_parquet_path, columns=_cols)
+
+    df_filtered = df.query(
+        f"overlap_area > {cfg.annotation_percent_filter_threshold} * tile_area"
+    ).reset_index(drop=True)
+
+    if cfg.multiclass:
+        df_filtered = df_filtered[df_filtered["annotation"] != 0].copy()
+        df_filtered["y"] = df_filtered["annotation"].astype(int)
+        n_classes = df_filtered["y"].nunique()
+        logger.info(
+            "Multiclass mode: %d classes → %s", n_classes, sorted(df_filtered["y"].unique())
+        )
+    else:
+        df_filtered["y"] = (df_filtered["annotation"] == cfg.positive_annotation_label).astype(int)
+
+    feature_cols = [c for c in df_filtered.columns if c.startswith("feature_")]
+    if df_filtered.empty:
+        raise ValueError(
+            "No tiles remain after filtering. Check annotation_percent_filter_threshold "
+            "and that the parquet file is non-empty."
+        )
+    if not feature_cols:
+        raise ValueError(
+            "No feature columns (starting with 'feature_') found in the parquet file."
+        )
+    if cfg.umap_n_components != 2:
+        raise ValueError(
+            f"umap_n_components must be 2 for scatter plotting, got {cfg.umap_n_components}."
+        )
+    logger.info(
+        "%d tiles  %d slides  %d features",
+        len(df_filtered),
+        df_filtered["slide_id"].nunique(),
+        len(feature_cols),
+    )
+
+    df_filtered = df_filtered.reset_index(drop=True)
+    X_raw = df_filtered[feature_cols].values.astype(np.float32)
+    y_true = df_filtered["y"].values
+
+    # Scale once; all algorithms work in the same normalised feature space.
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X_raw)
+
+    algo_names = list(cfg.algorithms)
+    summary: dict = {}
+    rows: list = []
+
+    # Per-algorithm labels stored for UMAP coloring
+    labels_by_algo: dict = {}
+
+    for algo in algo_names:
+        logger.info("── %s " + "─" * 50, algo)
+        try:
+            labels = _fit_predict(algo, X_scaled, cfg)
+        except Exception as exc:
+            logger.error("Algorithm '%s' failed: %s", algo, exc)
+            continue
+
+        labels_by_algo[algo] = labels
+
+        tile_m = _compute_cluster_metrics(y_true, labels, X_scaled, "tile", algo, random_state=cfg.random_state)
+        slide_m = _slide_level_metrics(df_filtered, labels, algo)
+
+        summary[algo] = {**tile_m, **slide_m}
+        row = {"algorithm": algo}
+        row.update(tile_m)
+        row.update(slide_m)
+        rows.append(row)
+
+    # ── Save tabular outputs ───────────────────────────────────────────────────
+    metrics_df = pd.DataFrame(rows)
+    metrics_df.to_csv(cfg.output_metrics_csv, index=False)
+    logger.info("Saved metrics CSV → %s", cfg.output_metrics_csv)
+
+    with open(cfg.output_summary_json, "w") as f:
+        json.dump(_sanitize_for_json(summary), f, indent=2)
+    logger.info("Saved summary JSON → %s", cfg.output_summary_json)
+
+    # ── UMAP visualisation ─────────────────────────────────────────────────────
+    if not labels_by_algo:
+        logger.warning("No algorithms produced results — skipping UMAP plot.")
+        return
+
+    try:
+        import umap as umap_module
+
+        n = len(X_scaled)
+        if cfg.umap_subsample > 0 and n > cfg.umap_subsample:
+            rng = np.random.RandomState(cfg.random_state)
+            subsample_idx = rng.choice(n, cfg.umap_subsample, replace=False)
+        else:
+            subsample_idx = np.arange(n)
+
+        X_sub = X_scaled[subsample_idx]
+        reducer = umap_module.UMAP(
+            n_neighbors=cfg.umap_n_neighbors,
+            min_dist=cfg.umap_min_dist,
+            n_components=cfg.umap_n_components,
+            random_state=cfg.random_state,
+        )
+        embedding = reducer.fit_transform(X_sub)
+
+        _plot_umap(
+            embedding,
+            subsample_idx,
+            labels_by_algo,
+            y_true,
+            cfg.output_umap_png,
+            list(labels_by_algo.keys()),
+        )
+    except ImportError:
+        logger.warning("umap-learn is not installed — skipping UMAP plot.")
+
+    logger.info("Done.")

--- a/mussel/cli/clustering_benchmark.py
+++ b/mussel/cli/clustering_benchmark.py
@@ -400,11 +400,12 @@ def main(cfg: ClusteringBenchmarkConfig):
 
     try:
         import umap as umap_module
-    except ImportError as exc:
-        raise ImportError(
-            "umap-learn is required for UMAP visualisation. "
-            "Install it with: pip install umap-learn"
-        ) from exc
+    except ImportError:
+        logger.warning(
+            "umap-learn is not installed — skipping UMAP plot. "
+            "Install it with: uv sync --extra umap  (or: pip install umap-learn)"
+        )
+        return
 
     n = len(X_scaled)
     if cfg.umap_subsample > 0 and n > cfg.umap_subsample:

--- a/mussel/cli/clustering_benchmark.py
+++ b/mussel/cli/clustering_benchmark.py
@@ -45,8 +45,8 @@ class ClusteringBenchmarkConfig:
     dbscan_min_samples (int): DBSCAN minimum samples per core point (default 5).
     umap_n_neighbors (int): UMAP n_neighbors (default 15).
     umap_min_dist (float): UMAP min_dist (default 0.1).
-    umap_n_components (int): UMAP output dimensionality — must be 2 for plotting
-        (default 2).
+    umap_n_components (int): UMAP output dimensionality — 2 for 2-D plots or 3 for
+        3-D scatter plots (default 2).
     umap_subsample (int): Maximum number of tiles used for UMAP projection (random
         subsample for speed; default 10000). Use 0 to disable subsampling.
     random_state (int): Random seed (default 42).
@@ -252,31 +252,33 @@ def _plot_umap(
     """UMAP scatter-plot grid.
 
     Rows = algorithms, columns = [cluster coloring, annotation coloring].
+    Supports both 2-D (embedding with 2 columns) and 3-D (3 columns).
     """
     n_algos = len(algo_names)
-    fig, axes = plt.subplots(n_algos, 2, figsize=(10, 4 * n_algos), squeeze=False)
+    n_components = embedding.shape[1]
+    is_3d = n_components == 3
+
+    fig = plt.figure(figsize=(10, 4 * n_algos))
 
     for row, algo in enumerate(algo_names):
         cluster_labels = labels_by_algo[algo][subsample_idx]
         annot_labels = true_labels[subsample_idx]
 
+        proj = "3d" if is_3d else None
+        ax_cl = fig.add_subplot(n_algos, 2, row * 2 + 1, projection=proj)
+        ax_an = fig.add_subplot(n_algos, 2, row * 2 + 2, projection=proj)
+
+        coords = tuple(embedding[:, i] for i in range(n_components))
+
         # Left: cluster coloring
-        ax_cl = axes[row][0]
-        scatter = ax_cl.scatter(
-            embedding[:, 0], embedding[:, 1],
-            c=cluster_labels, cmap="tab20", s=2, alpha=0.5, rasterized=True,
-        )
+        scatter = ax_cl.scatter(*coords, c=cluster_labels, cmap="tab20", s=2, alpha=0.5, rasterized=True)
         plt.colorbar(scatter, ax=ax_cl, label="Cluster")
         ax_cl.set_title(f"{algo} — clusters")
         ax_cl.set_xlabel("UMAP-1")
         ax_cl.set_ylabel("UMAP-2")
 
         # Right: annotation coloring
-        ax_an = axes[row][1]
-        scatter2 = ax_an.scatter(
-            embedding[:, 0], embedding[:, 1],
-            c=annot_labels, cmap="tab10", s=2, alpha=0.5, rasterized=True,
-        )
+        scatter2 = ax_an.scatter(*coords, c=annot_labels, cmap="tab10", s=2, alpha=0.5, rasterized=True)
         plt.colorbar(scatter2, ax=ax_an, label="Annotation")
         ax_an.set_title(f"{algo} — annotation")
         ax_an.set_xlabel("UMAP-1")
@@ -337,9 +339,9 @@ def main(cfg: ClusteringBenchmarkConfig):
         raise ValueError(
             "No feature columns (starting with 'feature_') found in the parquet file."
         )
-    if cfg.umap_n_components != 2:
+    if cfg.umap_n_components not in (2, 3):
         raise ValueError(
-            f"umap_n_components must be 2 for scatter plotting, got {cfg.umap_n_components}."
+            f"umap_n_components must be 2 or 3, got {cfg.umap_n_components}."
         )
     logger.info(
         "%d tiles  %d slides  %d features",
@@ -398,32 +400,35 @@ def main(cfg: ClusteringBenchmarkConfig):
 
     try:
         import umap as umap_module
+    except ImportError as exc:
+        raise ImportError(
+            "umap-learn is required for UMAP visualisation. "
+            "Install it with: pip install umap-learn"
+        ) from exc
 
-        n = len(X_scaled)
-        if cfg.umap_subsample > 0 and n > cfg.umap_subsample:
-            rng = np.random.RandomState(cfg.random_state)
-            subsample_idx = rng.choice(n, cfg.umap_subsample, replace=False)
-        else:
-            subsample_idx = np.arange(n)
+    n = len(X_scaled)
+    if cfg.umap_subsample > 0 and n > cfg.umap_subsample:
+        rng = np.random.RandomState(cfg.random_state)
+        subsample_idx = rng.choice(n, cfg.umap_subsample, replace=False)
+    else:
+        subsample_idx = np.arange(n)
 
-        X_sub = X_scaled[subsample_idx]
-        reducer = umap_module.UMAP(
-            n_neighbors=cfg.umap_n_neighbors,
-            min_dist=cfg.umap_min_dist,
-            n_components=cfg.umap_n_components,
-            random_state=cfg.random_state,
-        )
-        embedding = reducer.fit_transform(X_sub)
+    X_sub = X_scaled[subsample_idx]
+    reducer = umap_module.UMAP(
+        n_neighbors=cfg.umap_n_neighbors,
+        min_dist=cfg.umap_min_dist,
+        n_components=cfg.umap_n_components,
+        random_state=cfg.random_state,
+    )
+    embedding = reducer.fit_transform(X_sub)
 
-        _plot_umap(
-            embedding,
-            subsample_idx,
-            labels_by_algo,
-            y_true,
-            cfg.output_umap_png,
-            list(labels_by_algo.keys()),
-        )
-    except ImportError:
-        logger.warning("umap-learn is not installed — skipping UMAP plot.")
+    _plot_umap(
+        embedding,
+        subsample_idx,
+        labels_by_algo,
+        y_true,
+        cfg.output_umap_png,
+        list(labels_by_algo.keys()),
+    )
 
     logger.info("Done.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "hydra-core",
   "geopandas",
   "scikit-learn",
+  "umap-learn",
   # NOTE: Upper bound kept in sync with the fastattn extra, which pins transformers==4.36.2
   # and a narrow huggingface-hub range. Relax this once the fastattn stack is updated/tested.
   "transformers<4.46",
@@ -185,6 +186,7 @@ tessellate_extract_features = 'mussel.cli.tessellate_extract_features:main'
 create_class_embeddings = 'mussel.cli.create_class_embeddings:main'
 merge_annotation_features = 'mussel.cli.merge_annotation_features:main'
 linear_probe_benchmark = 'mussel.cli.linear_probe_benchmark:main'
+clustering_benchmark = 'mussel.cli.clustering_benchmark:main'
 export_tiles = 'mussel.cli.export_tiles:main'
 save_model = 'mussel.cli.save_model:main'
 convert = 'mussel.cli.convert:main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "hydra-core",
   "geopandas",
   "scikit-learn",
-  "umap-learn",
   # NOTE: Upper bound kept in sync with the fastattn extra, which pins transformers==4.36.2
   # and a narrow huggingface-hub range. Relax this once the fastattn stack is updated/tested.
   "transformers<4.46",
@@ -100,6 +99,9 @@ dev = [
 "zarr" = [
   "zarr",
   "ome-zarr",
+]
+"umap" = [
+  "umap-learn",
 ]
 
 [tool.uv]

--- a/tests/mussel/cli/test_clustering_benchmark.py
+++ b/tests/mussel/cli/test_clustering_benchmark.py
@@ -1,0 +1,358 @@
+import json
+import math
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from omegaconf import OmegaConf
+from shapely.geometry import box
+
+from mussel.cli.clustering_benchmark import (
+    ClusteringBenchmarkConfig,
+    _cluster_purity,
+    _compute_cluster_metrics,
+    _fit_predict,
+    _sanitize_for_json,
+    _slide_level_metrics,
+    main,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_parquet(tmp_path, n_slides=20, tiles_per_slide=10, n_features=8, seed=0):
+    """Create a synthetic GeoParquet file with feature columns and annotations."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for slide_idx in range(n_slides):
+        slide_id = f"slide_{slide_idx:03d}"
+        annotation = 2 if slide_idx < n_slides // 2 else 1
+        for tile_idx in range(tiles_per_slide):
+            feature_vals = rng.standard_normal(n_features)
+            row = {
+                "slide_id": slide_id,
+                "annotation": annotation,
+                "overlap_area": 0.8,
+                "tile_area": 1.0,
+                "geometry": box(tile_idx * 256, 0, (tile_idx + 1) * 256, 256),
+            }
+            for i, v in enumerate(feature_vals):
+                row[f"feature_{i}"] = v
+            rows.append(row)
+
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry")
+    path = str(tmp_path / "features.parquet")
+    gdf.to_parquet(path)
+    return path
+
+
+def _make_df(n_slides=20, tiles_per_slide=10, n_features=4, seed=0, multiclass=False):
+    """Return an in-memory DataFrame (no file I/O) for unit tests."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    n_classes = 3 if multiclass else 2
+    for s in range(n_slides):
+        slide_id = f"slide_{s:03d}"
+        annotation = (s % n_classes) + 1  # 1, 2, or 3 (no zero)
+        for t in range(tiles_per_slide):
+            row = {
+                "slide_id": slide_id,
+                "annotation": annotation,
+                "overlap_area": 0.8,
+                "tile_area": 1.0,
+            }
+            for i, v in enumerate(rng.standard_normal(n_features)):
+                row[f"feature_{i}"] = v
+            rows.append(row)
+    df = pd.DataFrame(rows)
+    df["y"] = df["annotation"].astype(int)
+    return df
+
+
+def _cfg(tmp_path, parquet_path, **overrides):
+    defaults = dict(
+        features_annotation_parquet_path=parquet_path,
+        output_metrics_csv=str(tmp_path / "metrics.csv"),
+        output_summary_json=str(tmp_path / "results.json"),
+        output_umap_png=str(tmp_path / "umap.png"),
+        annotation_percent_filter_threshold=0.5,
+        positive_annotation_label=2,
+        multiclass=False,
+        algorithms=["kmeans"],
+        n_clusters=2,
+        dbscan_eps=0.5,
+        dbscan_min_samples=5,
+        umap_n_neighbors=5,
+        umap_min_dist=0.1,
+        umap_n_components=2,
+        umap_subsample=50,
+        random_state=42,
+    )
+    defaults.update(overrides)
+    return OmegaConf.structured(ClusteringBenchmarkConfig(**defaults))
+
+
+def _fake_umap_module(n_rows: int) -> MagicMock:
+    """Return a mock umap module whose UMAP().fit_transform() returns zeros."""
+    fake = MagicMock()
+    fake.UMAP.return_value.fit_transform.return_value = np.zeros((n_rows, 2))
+    return fake
+
+
+# ── Unit tests: _cluster_purity ───────────────────────────────────────────────
+
+
+def test_cluster_purity_perfect():
+    """Purity is 1.0 when each cluster contains only one class."""
+    lt = np.array([0, 0, 0, 1, 1, 1])
+    lp = np.array([0, 0, 0, 1, 1, 1])
+    assert _cluster_purity(lt, lp) == pytest.approx(1.0)
+
+
+def test_cluster_purity_random():
+    """Purity lies in [0, 1] for a random assignment."""
+    rng = np.random.default_rng(0)
+    lt = rng.integers(0, 2, size=100)
+    lp = rng.integers(0, 3, size=100)
+    p = _cluster_purity(lt, lp)
+    assert 0.0 <= p <= 1.0
+
+
+def test_cluster_purity_excludes_noise():
+    """DBSCAN noise tiles (label -1) are excluded from purity."""
+    lt = np.array([0, 0, 1, 1])
+    lp = np.array([-1, 0, 1, -1])  # two noise points
+    # Only (lt=0, lp=0) and (lt=1, lp=1) contribute; both match → purity = 1.0
+    assert _cluster_purity(lt, lp) == pytest.approx(1.0)
+
+
+def test_cluster_purity_all_noise():
+    """Purity is NaN when every tile is labelled noise."""
+    lt = np.array([0, 1, 0])
+    lp = np.array([-1, -1, -1])
+    assert math.isnan(_cluster_purity(lt, lp))
+
+
+def test_cluster_purity_multiclass():
+    """Purity works correctly with labels 1, 2, 3 (non-zero multiclass)."""
+    lt = np.array([1, 1, 2, 2, 3, 3])
+    lp = np.array([0, 0, 1, 1, 2, 2])  # perfect 1-to-1 cluster-class mapping
+    assert _cluster_purity(lt, lp) == pytest.approx(1.0)
+
+
+# ── Unit tests: _compute_cluster_metrics ─────────────────────────────────────
+
+
+def test_compute_cluster_metrics_binary():
+    """Metrics dict contains expected keys and values in range for a simple binary case."""
+    rng = np.random.default_rng(1)
+    n = 100
+    X = rng.standard_normal((n, 8)).astype(np.float32)
+    lt = (rng.random(n) > 0.5).astype(int)
+    lp = lt.copy()  # perfect clustering
+    m = _compute_cluster_metrics(lt, lp, X, "tile", "test_algo")
+    assert "nmi" in m and "ari" in m and "purity" in m and "silhouette" in m
+    assert m["nmi"] == pytest.approx(1.0, abs=1e-6)
+    assert m["ari"] == pytest.approx(1.0, abs=1e-6)
+    assert m["purity"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_compute_cluster_metrics_all_noise():
+    """When all predictions are -1 (DBSCAN noise), metrics are NaN."""
+    rng = np.random.default_rng(2)
+    X = rng.standard_normal((20, 4)).astype(np.float32)
+    lt = np.ones(20, dtype=int)
+    lp = np.full(20, -1)
+    m = _compute_cluster_metrics(lt, lp, X, "tile", "dbscan")
+    assert math.isnan(m["nmi"])
+    assert math.isnan(m["ari"])
+    assert math.isnan(m["purity"])
+    assert m["n_clusters_found"] == 0
+
+
+# ── Unit tests: _slide_level_metrics ─────────────────────────────────────────
+
+
+def test_slide_level_metrics_basic():
+    """Slide-level metrics keys are present and values are in valid range."""
+    df = _make_df(n_slides=10, tiles_per_slide=5, n_features=4)
+    # Cluster 0 for first 5 slides, cluster 1 for last 5
+    labels = np.array([0] * 25 + [1] * 25)
+    m = _slide_level_metrics(df, labels, "kmeans")
+    assert "slide_nmi" in m
+    assert -1.0 <= m["slide_ari"] <= 1.0
+    assert 0.0 <= m["slide_purity"] <= 1.0
+
+
+def test_slide_level_metrics_single_class():
+    """Returns empty dict when all slides have the same label (degenerate case)."""
+    df = _make_df(n_slides=10, tiles_per_slide=5, n_features=4)
+    df["y"] = 1  # override: single class
+    labels = np.zeros(len(df), dtype=int)
+    m = _slide_level_metrics(df, labels, "kmeans")
+    assert m == {}
+
+
+# ── Unit tests: _fit_predict ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("algo", ["kmeans", "hierarchical", "dbscan"])
+def test_fit_predict_output_shape(algo):
+    """fit_predict returns an integer array with the same length as input."""
+    rng = np.random.default_rng(3)
+    X = rng.standard_normal((50, 8)).astype(np.float32)
+    cfg = ClusteringBenchmarkConfig(
+        features_annotation_parquet_path="dummy",
+        n_clusters=2,
+        dbscan_eps=1.0,
+        dbscan_min_samples=3,
+    )
+    labels = _fit_predict(algo, X, cfg)
+    assert labels.shape == (50,)
+    assert labels.dtype.kind in ("i", "u")  # integer type
+
+
+def test_fit_predict_unknown_algo():
+    """Unknown algorithm name raises ValueError."""
+    rng = np.random.default_rng(4)
+    X = rng.standard_normal((20, 4)).astype(np.float32)
+    cfg = ClusteringBenchmarkConfig(features_annotation_parquet_path="dummy")
+    with pytest.raises(ValueError, match="Unknown algorithm"):
+        _fit_predict("neural_chaos", X, cfg)
+
+
+# ── Unit tests: _sanitize_for_json ───────────────────────────────────────────
+
+
+def test_sanitize_nan_inf():
+    obj = {"a": float("nan"), "b": float("inf"), "c": 1.0, "d": [float("nan"), 2.0]}
+    clean = _sanitize_for_json(obj)
+    assert clean["a"] is None
+    assert clean["b"] is None
+    assert clean["c"] == pytest.approx(1.0)
+    assert clean["d"][0] is None
+    assert clean["d"][1] == pytest.approx(2.0)
+
+
+# ── Unit tests: validation ────────────────────────────────────────────────────
+
+
+def test_main_raises_on_invalid_umap_components(tmp_path):
+    """main() raises ValueError when umap_n_components != 2."""
+    parquet_path = _make_parquet(tmp_path)
+    cfg = _cfg(tmp_path, parquet_path, umap_n_components=3)
+    import mussel.cli.clustering_benchmark as cb
+
+    with pytest.raises(ValueError, match="umap_n_components must be 2"):
+        cb.main.__wrapped__(cfg)
+
+
+# ── Integration tests: main() ─────────────────────────────────────────────────
+
+
+def test_main_end_to_end_kmeans(tmp_path):
+    """Full main() invocation with kmeans produces all expected output files."""
+    parquet_path = _make_parquet(tmp_path)
+    n_tiles = 200  # 20 slides × 10 tiles
+    cfg = _cfg(tmp_path, parquet_path, algorithms=["kmeans"], umap_subsample=0)
+    import mussel.cli.clustering_benchmark as cb
+
+    with patch.dict(sys.modules, {"umap": _fake_umap_module(n_tiles)}):
+        cb.main.__wrapped__(cfg)
+
+    assert os.path.exists(cfg.output_metrics_csv)
+    assert os.path.exists(cfg.output_summary_json)
+
+    with open(cfg.output_summary_json) as f:
+        data = json.load(f)
+    assert "kmeans" in data
+    assert "nmi" in data["kmeans"]
+
+
+def test_main_end_to_end_dbscan(tmp_path):
+    """DBSCAN path runs without errors and produces outputs."""
+    parquet_path = _make_parquet(tmp_path)
+    n_tiles = 200
+    cfg = _cfg(
+        tmp_path,
+        parquet_path,
+        algorithms=["dbscan"],
+        dbscan_eps=2.0,
+        dbscan_min_samples=2,
+        umap_subsample=0,
+    )
+    import mussel.cli.clustering_benchmark as cb
+
+    with patch.dict(sys.modules, {"umap": _fake_umap_module(n_tiles)}):
+        cb.main.__wrapped__(cfg)
+
+    assert os.path.exists(cfg.output_summary_json)
+    with open(cfg.output_summary_json) as f:
+        data = json.load(f)
+    assert "dbscan" in data
+
+
+def test_main_end_to_end_multiclass(tmp_path):
+    """Multiclass mode runs and produces outputs."""
+    rng = np.random.default_rng(42)
+    rows = []
+    n_slides = 30
+    for s in range(n_slides):
+        annotation = (s % 3) + 1  # classes 1, 2, 3
+        for t in range(10):
+            row = {
+                "slide_id": f"slide_{s:03d}",
+                "annotation": annotation,
+                "overlap_area": 0.8,
+                "tile_area": 1.0,
+                "geometry": box(t * 256, 0, (t + 1) * 256, 256),
+            }
+            for i, v in enumerate(rng.standard_normal(8)):
+                row[f"feature_{i}"] = v
+            rows.append(row)
+    gdf = gpd.GeoDataFrame(rows, geometry="geometry")
+    parquet_path = str(tmp_path / "multi.parquet")
+    gdf.to_parquet(parquet_path)
+
+    n_tiles = 300
+    cfg = _cfg(
+        tmp_path,
+        parquet_path,
+        algorithms=["kmeans"],
+        n_clusters=3,
+        multiclass=True,
+        umap_subsample=0,
+    )
+    import mussel.cli.clustering_benchmark as cb
+
+    with patch.dict(sys.modules, {"umap": _fake_umap_module(n_tiles)}):
+        cb.main.__wrapped__(cfg)
+
+    assert os.path.exists(cfg.output_summary_json)
+    with open(cfg.output_summary_json) as f:
+        data = json.load(f)
+    assert "kmeans" in data
+
+
+def test_main_umap_subsample(tmp_path):
+    """When umap_subsample > 0, UMAP receives a subsampled feature matrix."""
+    parquet_path = _make_parquet(tmp_path)
+    subsample = 50
+    cfg = _cfg(tmp_path, parquet_path, algorithms=["kmeans"], umap_subsample=subsample)
+    import mussel.cli.clustering_benchmark as cb
+
+    fake = _fake_umap_module(subsample)
+    with patch.dict(sys.modules, {"umap": fake}):
+        cb.main.__wrapped__(cfg)
+
+    # UMAP.fit_transform should have been called with `subsample` rows
+    call_args = fake.UMAP.return_value.fit_transform.call_args
+    assert call_args is not None
+    X_passed = call_args[0][0]
+    assert X_passed.shape[0] == subsample
+

--- a/tests/mussel/cli/test_clustering_benchmark.py
+++ b/tests/mussel/cli/test_clustering_benchmark.py
@@ -243,12 +243,12 @@ def test_sanitize_nan_inf():
 
 
 def test_main_raises_on_invalid_umap_components(tmp_path):
-    """main() raises ValueError when umap_n_components != 2."""
+    """main() raises ValueError when umap_n_components is not 2 or 3."""
     parquet_path = _make_parquet(tmp_path)
-    cfg = _cfg(tmp_path, parquet_path, umap_n_components=3)
+    cfg = _cfg(tmp_path, parquet_path, umap_n_components=4)
     import mussel.cli.clustering_benchmark as cb
 
-    with pytest.raises(ValueError, match="umap_n_components must be 2"):
+    with pytest.raises(ValueError, match="umap_n_components must be 2 or 3"):
         cb.main.__wrapped__(cfg)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1854,6 +1854,22 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/f5/a1bde3aa8c43524b0acaf3f72fb3d80a32dd29dbb42d7dc434f84584cdcc/llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17", size = 37232772, upload-time = "2026-03-31T18:28:12.198Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fb/76d88fc05ee1f9c1a6efe39eb493c4a727e5d1690412469017cd23bcb776/llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7", size = 56275179, upload-time = "2026-03-31T18:28:15.725Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/08/29da7f36217abd56a0c389ef9a18bea47960826e691ced1a36c92c6ce93c/llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063", size = 55128632, upload-time = "2026-03-31T18:28:19.946Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/5e12e9ed447d65f04acf6fcf2d79cded2355640b5131a46cee4c99a5949d/llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea", size = 38138402, upload-time = "2026-03-31T18:28:23.327Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+]
+
+[[package]]
 name = "locket"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2168,7 +2184,7 @@ wheels = [
 
 [[package]]
 name = "mussel"
-version = "1.3.0"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "configargparse" },
@@ -2191,6 +2207,7 @@ dependencies = [
     { name = "tiffslide" },
     { name = "tqdm" },
     { name = "transformers" },
+    { name = "umap-learn" },
 ]
 
 [package.optional-dependencies]
@@ -2359,6 +2376,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'torch-gpu'", index = "https://download.pytorch.org/whl/cu121", conflict = { package = "mussel", extra = "torch-gpu" } },
     { name = "tqdm" },
     { name = "transformers", specifier = "<4.46" },
+    { name = "umap-learn" },
     { name = "wandb", marker = "extra == 'fastattn'" },
     { name = "webdataset", marker = "extra == 'fastattn'" },
     { name = "xformers", marker = "extra == 'fastattn'", specifier = ">=0.0.34", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "mussel", extra = "fastattn" } },
@@ -2529,6 +2547,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/ee/53df34fcc9c0b1db62b2f2e2c848e28d9354e1c7f0dce029ee50b16ca157/ninja-1.11.1.1-py2.py3-none-win32.whl", hash = "sha256:fa2ba9d74acfdfbfbcf06fad1b8282de8a7a8c481d9dee45c859a8c93fcc1082", size = 265049, upload-time = "2023-10-09T18:00:08.294Z" },
     { url = "https://files.pythonhosted.org/packages/b6/2f/a3bc50fa63fc4fe9348e15b53dc8c87febfd4e0c660fcf250c4b19a3aa3b/ninja-1.11.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:95da904130bfa02ea74ff9c0116b4ad266174fafb1c707aa50212bc7859aebf1", size = 312958, upload-time = "2023-10-09T18:00:10.278Z" },
     { url = "https://files.pythonhosted.org/packages/73/2a/f5b7b3b7ecd5cf4e31375580bf5c6a01a328ed1ebdfff90fab463e3f4bc7/ninja-1.11.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:185e0641bde601e53841525c4196278e9aaf4463758da6dd1e752c0a0f54136a", size = 272686, upload-time = "2023-10-09T18:00:11.964Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1b/3c5a7daf683a95465bf23504bcd1a2d5db8cd5e5e276ca87505d020dffe9/numba-0.65.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9d993ed0a257aa4116e6f553f114004bcfdee540c7276ab8ea48f650d514c452", size = 2680870, upload-time = "2026-04-24T02:02:10.623Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a4/1831836814018a898e7d252aebe09c0f3ce1f26d145b68264b4ae0be6822/numba-0.65.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f098109f361681e57295f7e84d8ab2426902539a141811de0703ace52826981", size = 3739780, upload-time = "2026-04-24T02:02:13.097Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1b/a813ddc81def09e257d2b1f67521982ce4b06204a87268796ffc8187271c/numba-0.65.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973fd8173f2312815e6b7aaae887c4ce8a817eeff46a4f8840b828305b75bc95", size = 3446722, upload-time = "2026-04-24T02:02:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/ee1d8b3becda384fe0552221641e05aa668a35e8a77470db4db7f6475000/numba-0.65.1-cp310-cp310-win_amd64.whl", hash = "sha256:c63aa0c4193694026452da55d0ef9d85156c1a7a333454c103bb30dec81b7bf8", size = 2747539, upload-time = "2026-04-24T02:02:16.79Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/650500c2eab4534d98e9166f4298e0f3c69c742afdf24e6eabccd1f16ad8/numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9", size = 2680563, upload-time = "2026-04-24T02:02:18.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420", size = 3745018, upload-time = "2026-04-24T02:02:20.252Z" },
+    { url = "https://files.pythonhosted.org/packages/49/aa/4361698f35bf63bff67dfe6c90493731177f48ede954f77b0588731537bc/numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6", size = 3450962, upload-time = "2026-04-24T02:02:22.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9a/af61ec03b3116c161fd7a06b9e8a265729a8718458333e8ffbb06d9a3978/numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4", size = 2747417, upload-time = "2026-04-24T02:02:24.43Z" },
 ]
 
 [[package]]
@@ -4108,6 +4146,23 @@ crypto = [
 ]
 
 [[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
+]
+
+[[package]]
 name = "pyogrio"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5363,10 +5418,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:269b10c34430aa8e9643dbe035dc525c4a9b1d671cd3dbc8ecbcaed280ae322d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:23d062bf70776a3d04dbe74db950db2a5245e1ba4f27208a87f0d743b0d06e86" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b3203f191bc40783c99488d2e776dcf93ac431a59491d627a1ca5b3ae20b22" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:31f8c39660962f9ae4eeec995e3049b5492eb7360dd4f07377658ef4d728fa4c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:269b10c34430aa8e9643dbe035dc525c4a9b1d671cd3dbc8ecbcaed280ae322d", upload-time = "2024-10-29T23:01:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:23d062bf70776a3d04dbe74db950db2a5245e1ba4f27208a87f0d743b0d06e86", upload-time = "2024-10-29T23:02:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b3203f191bc40783c99488d2e776dcf93ac431a59491d627a1ca5b3ae20b22", upload-time = "2024-10-29T23:02:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:31f8c39660962f9ae4eeec995e3049b5492eb7360dd4f07377658ef4d728fa4c", upload-time = "2024-10-29T23:02:11Z" },
 ]
 
 [[package]]
@@ -5388,10 +5443,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:7f91a2200e352745d70e22396bd501448e28350fbdbd8d8b1c83037e25451150" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:df93157482b672892d29134d3fae9d38ba3219702faedd79f407eb36774c56ce" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:07d7c9e069123d5af08b0cf0013d74f680b2d8be7d9e2cf561a52c90c55d9409" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:81531d4d5ca74163dc9574b87396531e546a60cceb6253303c7db6a21e867fdf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:7f91a2200e352745d70e22396bd501448e28350fbdbd8d8b1c83037e25451150", upload-time = "2024-10-29T23:00:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:df93157482b672892d29134d3fae9d38ba3219702faedd79f407eb36774c56ce", upload-time = "2024-10-29T23:00:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:07d7c9e069123d5af08b0cf0013d74f680b2d8be7d9e2cf561a52c90c55d9409", upload-time = "2024-10-29T23:00:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:81531d4d5ca74163dc9574b87396531e546a60cceb6253303c7db6a21e867fdf", upload-time = "2024-10-29T23:01:02Z" },
 ]
 
 [[package]]
@@ -5431,10 +5486,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra != 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra != 'extra-6-mussel-fastattn' and extra != 'extra-6-mussel-tensorflow-cpu' and extra != 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:9b22d6d98aa56f9317902dec0e066814a6edba1aada90110ceea2bb0678df22f" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:c8ab8c92eab928a93c483f83ca8c63f13dafc10fc93ad90ed2dcb7c82ea50410" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:4bcee18f00c43c815efad8efaa3bca584ffdc8d2cd35ef4c44c814f2739d9191" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14", upload-time = "2024-10-29T23:15:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:9b22d6d98aa56f9317902dec0e066814a6edba1aada90110ceea2bb0678df22f", upload-time = "2024-10-29T23:16:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:c8ab8c92eab928a93c483f83ca8c63f13dafc10fc93ad90ed2dcb7c82ea50410", upload-time = "2024-10-29T23:18:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:4bcee18f00c43c815efad8efaa3bca584ffdc8d2cd35ef4c44c814f2739d9191", upload-time = "2024-10-29T23:18:42Z" },
 ]
 
 [[package]]
@@ -5473,12 +5528,12 @@ dependencies = [
     { name = "typing-extensions", marker = "extra == 'extra-6-mussel-fastattn' or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:114d1cbab7de92bad7f7767d83b3e1bff2016331964d26c90a5f9a38b80b58a6", upload-time = "2026-04-27T20:46:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6f17bf3cc27463f0a0a9dd8e2312737551833948ca24099264bfed7295ad3669", upload-time = "2026-04-27T20:46:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:d0bd014a512f6e12ede57857d4c9a07056104c983b4a703672e9e4114f0bf414", upload-time = "2026-04-27T20:48:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:36ae7e5522b86e5d74d70f0c1a5b32eda3a0ae1635749060d0335a8856c778ea", upload-time = "2026-04-27T20:50:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a992bf8b3f2f4a8e0f2caf204ea1b1206466535eb485d4f61caf69a881e2fae7", upload-time = "2026-04-27T20:50:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:ce9aeead7950ae8eb48891568f9314a9a4130996b55e797c75e0c0d2846714ae", upload-time = "2026-04-27T20:52:26Z" },
 ]
 
 [[package]]
@@ -5513,10 +5568,10 @@ dependencies = [
     { name = "torch", version = "2.5.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-linux_aarch64.whl", hash = "sha256:75f8a4d51a593c4bab6c9bf7d75bdd88691b00a53b07656678bc55a3a753dd73" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4878fefb96ef293d06c27210918adc83c399d9faaf34cda5a63e129f772328f1" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:a40d766345927639da322c693934e5f91b1ba2218846c7104b868dea2314ce8e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:344b339e15e6bbb59ee0700772616d0afefd209920c762b1604368d8c3458322" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-linux_aarch64.whl", hash = "sha256:75f8a4d51a593c4bab6c9bf7d75bdd88691b00a53b07656678bc55a3a753dd73", upload-time = "2024-10-29T23:02:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4878fefb96ef293d06c27210918adc83c399d9faaf34cda5a63e129f772328f1", upload-time = "2024-10-29T23:02:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:a40d766345927639da322c693934e5f91b1ba2218846c7104b868dea2314ce8e", upload-time = "2024-10-29T23:02:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:344b339e15e6bbb59ee0700772616d0afefd209920c762b1604368d8c3458322", upload-time = "2024-10-29T23:02:46Z" },
 ]
 
 [[package]]
@@ -5534,10 +5589,10 @@ dependencies = [
     { name = "torch", version = "2.5.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:17bbc073920e429bf23a290472d51edc75e7b9809b81a93503d10d8edb6f3a6d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:58773dc7110425ff3ffa462ed32d5522deaed81179b24780136ebc493fb94feb" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:a4153bcc9f6219596c65761aa00588704e91e3db91d911c251e614f6140ed047" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:ebdeb19a49da0b5d11cc512a76b24a43971e17cfb9c1ec42564d0e300670d5fa" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:17bbc073920e429bf23a290472d51edc75e7b9809b81a93503d10d8edb6f3a6d", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:58773dc7110425ff3ffa462ed32d5522deaed81179b24780136ebc493fb94feb", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:a4153bcc9f6219596c65761aa00588704e91e3db91d911c251e614f6140ed047", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:ebdeb19a49da0b5d11cc512a76b24a43971e17cfb9c1ec42564d0e300670d5fa", upload-time = "2024-10-29T23:02:42Z" },
 ]
 
 [[package]]
@@ -5561,10 +5616,10 @@ dependencies = [
     { name = "torch", version = "2.5.1+cu121", source = { registry = "https://download.pytorch.org/whl/cu121" }, marker = "(extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra != 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra != 'extra-6-mussel-fastattn' and extra != 'extra-6-mussel-tensorflow-cpu' and extra != 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:304937b82c933d5155bd04d771f4b187273f67a76050bb4276b521f7e9b4c4e7" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:4cb1e44c1f7a4992f6d38a15633a1e694c093f1c52f3a036b1a719968031507a" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:237609a3551c2b68f32bcd3f3875dca93836010d83922ef2f3bd3a7540caee58" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:00143c941b30f2d5001b58f8caada826aaa4dce94b8ae4192730e5c34165fa8c" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:304937b82c933d5155bd04d771f4b187273f67a76050bb4276b521f7e9b4c4e7", upload-time = "2024-10-29T23:25:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:4cb1e44c1f7a4992f6d38a15633a1e694c093f1c52f3a036b1a719968031507a", upload-time = "2024-10-29T23:25:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:237609a3551c2b68f32bcd3f3875dca93836010d83922ef2f3bd3a7540caee58", upload-time = "2024-10-29T23:25:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:00143c941b30f2d5001b58f8caada826aaa4dce94b8ae4192730e5c34165fa8c", upload-time = "2024-10-29T23:25:42Z" },
 ]
 
 [[package]]
@@ -5591,12 +5646,12 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-6-mussel-fastattn' or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f00219ac240be76ac7693dc0459d19d35b3a6bc778aeb461d70fa24a78602f14" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8af0ce71fb0c8773daa16443ac5b65f21a0b18a501bcf4fc7750c03a76bfc9ef" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:233a63229f773ad63ba9f6ea4713d905839aecd58291a169b1bcee7c29356029" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a197ed1684633b95a49f89cc860bbff763674d737f5ba5100be74caa98acd9f" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26bc03574a5e1d3b48348292d523e089db8e833fac2f56a49ebbfde571b90db2" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f00219ac240be76ac7693dc0459d19d35b3a6bc778aeb461d70fa24a78602f14", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8af0ce71fb0c8773daa16443ac5b65f21a0b18a501bcf4fc7750c03a76bfc9ef", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:233a63229f773ad63ba9f6ea4713d905839aecd58291a169b1bcee7c29356029", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a197ed1684633b95a49f89cc860bbff763674d737f5ba5100be74caa98acd9f", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26bc03574a5e1d3b48348292d523e089db8e833fac2f56a49ebbfde571b90db2", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:67eb5dab7ae058e4a7ce44c682db8dbf28a9b381a658c7f778f08029d37574d4", upload-time = "2026-04-09T23:21:30Z" },
 ]
 
 [[package]]
@@ -5726,6 +5781,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
 ]
 
 [[package]]
@@ -5864,8 +5937,8 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl", hash = "sha256:bea6121a39992140ea7e3f61400c8964afc33a6f0b1e11abe654936de346e1d9", upload-time = "2026-04-27T21:22:38Z" },
+    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-win_amd64.whl", hash = "sha256:68f82ada282e30f8f3d61a6ba13d2baea92231dfa2e68795d616600e9cef4f57", upload-time = "2026-04-27T21:22:39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new `clustering_benchmark` CLI command that evaluates the quality of learned features using unsupervised clustering against ground-truth labels. This complements the existing `linear_probe_benchmark` (supervised) with an unsupervised evaluation approach.

## Features

- **Algorithms**: K-Means, Hierarchical (agglomerative), and DBSCAN
- **Metrics**: NMI, ARI, and purity at both tile and slide level
- **Slide-level aggregation**: majority vote for both predicted clusters and true labels
- **UMAP visualization**: optional scatter plot output (2D and 3D projections via `umap_n_components=2|3`); requires the optional `umap` extra
- **DBSCAN noise handling**: noise points (label -1) are excluded from all metrics
- **Same input format** as `linear_probe_benchmark`: GeoParquet with `slide_id`, `annotation`, and `feature_*` columns

## Usage

```bash
clustering_benchmark features_annotation_parquet_path=features.parquet
clustering_benchmark features_annotation_parquet_path=features.parquet algorithms=[kmeans] n_clusters=5
clustering_benchmark features_annotation_parquet_path=features.parquet algorithms=[dbscan]
clustering_benchmark features_annotation_parquet_path=features.parquet umap_n_components=3
```

## Changes

- `mussel/cli/clustering_benchmark.py` — new CLI command
- `tests/mussel/cli/test_clustering_benchmark.py` — 19 tests (all passing)
- `pyproject.toml`:
  - Added `clustering_benchmark` entry point
  - `umap-learn` added as an **optional** `umap` extra (not a core dependency); UMAP plot is skipped with a warning when not installed
- `Dockerfile` — pin `uv` image as a named stage to avoid fuse-overlayfs issues with inline `COPY --from`
- `README-commands.md` — full `### clustering_benchmark` section with parameter table and examples
- `uv.lock` — updated lock file
