### PR TITLE
feat: add embedding_precision parameter to feature extraction pipeline

### DIFF
--- a/README-commands.md
+++ b/README-commands.md
@@ -274,6 +274,37 @@ extract_features \
     output_pt_path=None
 ```
 
+#### Embedding precision
+
+By default embeddings are stored at full float32 precision. Use `embedding_precision`
+to reduce the on-disk and in-memory size of the HDF5 and `.pt` outputs:
+
+| Value | Bytes / dim | Notes |
+|---|---|---|
+| `float32` (default) | 4 | Full model precision |
+| `float16` | 2 | IEEE half-precision; cuts storage in half with slight loss of precision |
+| `bfloat16` | 2 | Brain-float: same exponent range as float32, less mantissa precision than float16; widely used in ML training |
+
+```bash
+extract_features \
+    slide_path=tests/testdata/948176.svs \
+    patch_h5_path=tests/testdata/948176.patch.h5 \
+    output_h5_path=948176_feat.h5 \
+    output_pt_path=948176_embed.pt \
+    embedding_precision=float16
+```
+
+The `embedding_precision` parameter is also supported by `tessellate_extract_features`:
+
+```bash
+tessellate_extract_features \
+    slide_path=slide.svs \
+    output_h5_path=out_feat.h5 \
+    output_pt_path=out_embed.pt \
+    model_type=VIRCHOW2 \
+    embedding_precision=bfloat16
+```
+
 ### `tessellate_extract_features`
 
 `tessellate_extract_features` runs tessellation and feature extraction in a single command.

--- a/mussel/cli/aggregate_slide_features.py
+++ b/mussel/cli/aggregate_slide_features.py
@@ -28,6 +28,8 @@ class AggregateSlideFeaturesConfig:
         gpu_device_id (Optional[int]): Specific GPU device ID to use.
         gpu_device_ids (Optional[List[int]]): List of GPU device IDs for multi-GPU inference.
         ssl_verify (bool): Whether to verify SSL certificates when downloading models or accessing remote resources (default: True).
+        embedding_precision (str): Numeric precision for saved embeddings.
+            Options: "float32" (default), "float16", "bfloat16".
     """
 
     patch_features_h5_path: str = MISSING
@@ -39,6 +41,7 @@ class AggregateSlideFeaturesConfig:
     gpu_device_id: Optional[int] = None
     gpu_device_ids: Optional[List[int]] = None
     ssl_verify: bool = True  # Whether to verify SSL certificates for remote operations
+    embedding_precision: str = "float32"
 
 
 desc_doc = """== ${hydra.help.app_name} ==
@@ -127,6 +130,7 @@ def main(cfg: AggregateSlideFeaturesConfig):
         use_gpu=cfg.use_gpu,
         gpu_device_id=cfg.gpu_device_id,
         gpu_device_ids=cfg.gpu_device_ids,
+        embedding_precision=cfg.embedding_precision,
     )
 
     logger.info(f"Slide features saved to: {cfg.output_h5_path}")

--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -116,6 +116,10 @@ class ExtractFeaturesConfig:
     gpu_device_ids: Optional[List[int]] = None
     num_workers: int = 16
     is_test_run: bool = False
+    embedding_precision: str = "float32"
+    """Numeric precision for saved patch embeddings. "float32" (default) keeps full precision;
+    "float16" halves storage size. Note: "float16" with aggregation_method="model" feeds
+    reduced-precision features to the slide encoder, which may affect quality."""
 
 
 desc_doc = """== ${hydra.help.app_name} ==
@@ -215,6 +219,7 @@ def _main_single(cfg: ExtractFeaturesConfig):
         aggregation_method=cfg.aggregation_method,
         slide_model_type=cfg.slide_model_type,
         slide_model_path=cfg.slide_model_path,
+        embedding_precision=cfg.embedding_precision,
     )
 
 
@@ -279,6 +284,7 @@ def _main_batch(cfg: ExtractFeaturesConfig):
             num_workers=cfg.num_workers,
             pin_memory=True,
             is_test_run=cfg.is_test_run,
+            embedding_precision=cfg.embedding_precision,
         )
 
         # Aggregate to slide level using batch processing
@@ -314,6 +320,7 @@ def _main_batch(cfg: ExtractFeaturesConfig):
             num_workers=cfg.num_workers,
             pin_memory=True,
             is_test_run=cfg.is_test_run,
+            embedding_precision=cfg.embedding_precision,
         )
 
         # Save as PT format for consistency

--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -83,6 +83,11 @@ class ExtractFeaturesConfig:
         gpu_device_id (Optional[int]): Specific GPU device ID to use, if applicable.
         gpu_device_ids (Optional[List[int]]): List of GPU device IDs to use, if applicable.
         num_workers (int): Number of worker threads for data loading.
+        embedding_precision (str): Numeric precision for saved patch embeddings.
+            "float32" (default) keeps full model precision; "float16" halves
+            storage size at the cost of reduced precision. Note: when using
+            aggregation_method="model", float16 features are fed to the slide
+            encoder, which may affect aggregation quality.
     """
 
     # Single mode parameters
@@ -117,9 +122,6 @@ class ExtractFeaturesConfig:
     num_workers: int = 16
     is_test_run: bool = False
     embedding_precision: str = "float32"
-    """Numeric precision for saved patch embeddings. "float32" (default) keeps full precision;
-    "float16" halves storage size. Note: "float16" with aggregation_method="model" feeds
-    reduced-precision features to the slide encoder, which may affect quality."""
 
 
 desc_doc = """== ${hydra.help.app_name} ==

--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -85,9 +85,10 @@ class ExtractFeaturesConfig:
         num_workers (int): Number of worker threads for data loading.
         embedding_precision (str): Numeric precision for saved patch embeddings.
             "float32" (default) keeps full model precision; "float16" halves
-            storage size at the cost of reduced precision. Note: when using
-            aggregation_method="model", float16 features are fed to the slide
-            encoder, which may affect aggregation quality.
+            storage size; "bfloat16" uses the brain-float format (same exponent
+            range as float32, less mantissa precision than float16). Note: when
+            using aggregation_method="model", reduced-precision features are fed
+            to the slide encoder, which may affect aggregation quality.
     """
 
     # Single mode parameters

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -152,6 +152,7 @@ class TessellateExtractFeaturesConfig:
     output_h5_suffix: str = "features.h5"
     output_pt_suffix: str = "features.pt"
     slide_batch_size: int = 8
+    max_slide_patches: Optional[int] = None  # Max patches per slide for slide-level models; large slides are subsampled
     # Common parameters
     classifier_pkl: Optional[str] = None
     classifier_threshold: float = 0.75
@@ -990,6 +991,7 @@ def _main_batch(
                     gpu_device_id=cfg.gpu_device_id,
                     gpu_device_ids=cfg.gpu_device_ids,
                     slide_batch_size=cfg.slide_batch_size,
+                    max_slide_patches=cfg.max_slide_patches,
                 )
             except Exception as e:
                 logger.error(f"Error during batch aggregation: {e}")

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -37,6 +37,7 @@ from mussel.utils import (aggregate_slide_features_batch,
                           resolve_aggregation_method, resolve_patch_encoder,
                           resolve_remote_paths, safe_path_join,
                           save_torch_tensor)
+from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
 
 # Private aliases used throughout this module
@@ -192,6 +193,7 @@ class TessellateExtractFeaturesConfig:
     aggregation_method: str = "identity"
     slide_model_type: Any = None  # Can be ModelType or List[ModelType]
     ssl_verify: bool = True  # Whether to verify SSL certificates for remote operations
+    embedding_precision: str = "float32"  # Precision for saved embeddings: "float32", "float16", or "bfloat16"
 
     def __post_init__(self):
         """Set default patch size based on model type if not explicitly set."""
@@ -894,7 +896,7 @@ def _main_batch(
                     f"{r['slide_id']}.{cfg.output_pt_suffix}",
                 )
                 with h5py.File(intermediate_h5_path, "r") as f:
-                    features = torch.from_numpy(f["features"][:])
+                    features = _numpy_to_torch(f["features"][:])
                 save_torch_tensor(pt_dest, features, ssl_verify=cfg.ssl_verify)
                 logger.debug(f"Saved PT features to {pt_dest}")
 
@@ -942,7 +944,10 @@ def _main_batch(
                 # Copy PT file
                 pt_dest = r["output_pt_path"]
                 with h5py.File(intermediate_h5_path, "r") as f:
-                    features = torch.from_numpy(f["features"][:])
+                    raw = f["features"][:]
+                feature_dtype = _parse_feature_dtype(cfg.embedding_precision)
+                features_arr = raw.astype(feature_dtype) if feature_dtype is not None else raw
+                features = _numpy_to_torch(features_arr)
                 save_torch_tensor(pt_dest, features, ssl_verify=cfg.ssl_verify)
                 logger.debug(f"Saved PT to {pt_dest}")
         elif aggregation_method == "model" and cfg.slide_model_type is None:
@@ -992,6 +997,7 @@ def _main_batch(
                     gpu_device_ids=cfg.gpu_device_ids,
                     slide_batch_size=cfg.slide_batch_size,
                     max_slide_patches=cfg.max_slide_patches,
+                    embedding_precision=cfg.embedding_precision,
                 )
             except Exception as e:
                 logger.error(f"Error during batch aggregation: {e}")
@@ -1081,7 +1087,10 @@ def _main_batch(
         # Save PT files and coords-only H5
         for i, r in enumerate(slide_results):
             with h5py.File(temp_output_h5_paths[i], "r") as f:
-                features = torch.from_numpy(f["features"][:])
+                raw = f["features"][:]
+                feature_dtype = _parse_feature_dtype(cfg.embedding_precision)
+                features_arr = raw.astype(feature_dtype) if feature_dtype is not None else raw
+                features = _numpy_to_torch(features_arr)
                 save_torch_tensor(
                     r["output_pt_path"], features, ssl_verify=cfg.ssl_verify
                 )

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -36,10 +36,15 @@ def _numpy_to_torch(arr: np.ndarray, dtype: Optional[np.dtype] = None) -> torch.
 
     Handles ml_dtypes.bfloat16 arrays (which torch.from_numpy cannot convert
     directly) by reinterpreting the raw uint16 bytes as torch.bfloat16.
-    When reading bfloat16 back from HDF5, h5py returns a |V2 (2-byte void) array;
-    pass ``dtype=np.dtype(ml_dtypes.bfloat16)`` to reinterpret it correctly.
+
+    h5py stores bfloat16 as |V2 (2-byte opaque void). This is detected automatically
+    so no dtype hint is needed; passing ``dtype=np.dtype(ml_dtypes.bfloat16)`` is
+    accepted for backward compatibility but redundant.
     """
-    if dtype is not None and dtype == np.dtype(ml_dtypes.bfloat16) and arr.dtype.kind == "V":
+    # Auto-detect |V2 (HDF5 bfloat16 representation) without requiring a dtype hint.
+    if arr.dtype.kind == "V" and arr.dtype.itemsize == 2:
+        arr = arr.view(ml_dtypes.bfloat16)
+    elif dtype is not None and dtype == np.dtype(ml_dtypes.bfloat16) and arr.dtype.kind == "V":
         arr = arr.view(ml_dtypes.bfloat16)
     if arr.dtype == np.dtype(ml_dtypes.bfloat16):
         return torch.from_numpy(arr.view(np.uint16)).view(torch.bfloat16)
@@ -773,20 +778,24 @@ def _apply_slide_aggregation(
     Returns:
         Numpy array of aggregated features.
     """
+    # Normalize |V2 (HDF5 bfloat16 representation) so all downstream ops see a proper dtype.
+    if features.dtype.kind == "V" and features.dtype.itemsize == 2:
+        features = features.view(ml_dtypes.bfloat16)
+
     if aggregation_method == "identity":
         # No aggregation - keep all patch features
         logger.info("Using identity aggregation (no aggregation)")
         return features
     elif aggregation_method == "mean":
-        # Mean pooling across patches
-        aggregated_features = np.mean(features, axis=0, keepdims=True)
+        # Mean pooling across patches; upcast to float32 so numpy ufuncs work reliably.
+        aggregated_features = np.mean(features.astype(np.float32), axis=0, keepdims=True)
         logger.info(
             f"Applied mean pooling: {features.shape} -> {aggregated_features.shape}"
         )
         return aggregated_features
     elif aggregation_method == "max":
-        # Max pooling across patches
-        aggregated_features = np.max(features, axis=0, keepdims=True)
+        # Max pooling across patches; upcast to float32 so numpy ufuncs work reliably.
+        aggregated_features = np.max(features.astype(np.float32), axis=0, keepdims=True)
         logger.info(
             f"Applied max pooling: {features.shape} -> {aggregated_features.shape}"
         )
@@ -814,8 +823,8 @@ def _apply_slide_aggregation(
             slide_model = model_factory.get_model(slide_model_path, use_gpu, gpu_device_id)
             model_fun = slide_model.get_model_fun()
 
-        # Convert features to tensor and apply model
-        features_tensor = torch.from_numpy(features).unsqueeze(0)  # Add batch dimension
+        # Convert features to tensor (handles bfloat16/V2 correctly) and apply model
+        features_tensor = _numpy_to_torch(features).unsqueeze(0)  # Add batch dimension
 
         # Some slide encoders require coordinates and/or patch size
         # GIGAPATH_SLIDE: requires (features, coords)
@@ -1526,7 +1535,7 @@ def aggregate_slide_features_batch(
                                 f"patch_size not provided, using default: {patch_size}"
                             )
 
-                        features_tensor = torch.from_numpy(features).unsqueeze(0)
+                        features_tensor = _numpy_to_torch(features).unsqueeze(0)
                         coords_tensor = torch.from_numpy(coords).long().unsqueeze(0)
                         agg_features = (
                             model_fun(features_tensor, coords_tensor, patch_size)
@@ -1555,7 +1564,7 @@ def aggregate_slide_features_batch(
                         if coords is None:
                             raise ValueError("GIGAPATH_SLIDE requires coordinates")
 
-                        features_tensor = torch.from_numpy(features).unsqueeze(
+                        features_tensor = _numpy_to_torch(features).unsqueeze(
                             0
                         )  # (1, N, D)
                         coords_tensor = torch.from_numpy(coords).unsqueeze(
@@ -1578,7 +1587,7 @@ def aggregate_slide_features_batch(
                 # Stack features from all slides in batch and process together
                 try:
                     features_list = [
-                        torch.from_numpy(f).unsqueeze(0) for f in batch_features
+                        _numpy_to_torch(f).unsqueeze(0) for f in batch_features
                     ]
                     features_batch = torch.cat(features_list, dim=0)
 

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1329,6 +1329,7 @@ def aggregate_slide_features_batch(
     gpu_device_id=None,
     gpu_device_ids=None,
     slide_batch_size=8,
+    max_slide_patches=None,
 ):
     """Aggregate patch-level features to slide-level for multiple slides (Step 2: Batch Slide Encoding).
 
@@ -1355,6 +1356,10 @@ def aggregate_slide_features_batch(
         gpu_device_id: GPU device ID to use.
         gpu_device_ids: List of GPU device IDs for multi-GPU.
         slide_batch_size: Number of slides to process in a single batch (default: 8).
+        max_slide_patches: Maximum number of patches per slide for model-based aggregation.
+            When a slide exceeds this limit, patches are randomly subsampled before encoding.
+            Useful for TITAN whose alibi attention is O(N²) and OOMs on very large slides.
+            None (default) disables subsampling.
 
     Returns:
         Tuple of (output_h5_paths, output_pt_paths) if saving.
@@ -1534,6 +1539,20 @@ def aggregate_slide_features_batch(
                             logger.warning(
                                 f"patch_size not provided, using default: {patch_size}"
                             )
+
+                        # Subsample patches if slide exceeds max_slide_patches.
+                        # TITAN's alibi attention is O(N²) — large slides (>~8k patches)
+                        # will OOM on most GPUs without subsampling.
+                        if max_slide_patches is not None and features.shape[0] > max_slide_patches:
+                            logger.warning(
+                                f"Slide {slide_name} has {features.shape[0]} patches, "
+                                f"subsampling to {max_slide_patches} for TITAN_SLIDE "
+                                f"(O(N²) attention limit)."
+                            )
+                            rng = np.random.default_rng(seed=abs(hash(slide_name)) % 2**32)
+                            indices = np.sort(rng.choice(features.shape[0], max_slide_patches, replace=False))
+                            features = features[indices]
+                            coords = coords[indices]
 
                         features_tensor = _numpy_to_torch(features).unsqueeze(0)
                         coords_tensor = torch.from_numpy(coords).long().unsqueeze(0)

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -37,7 +37,7 @@ def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
         embedding_precision: One of "float32" or "float16".
 
     Returns:
-        None if float32 (no cast needed), np.float16 if float16.
+        None if float32 (no cast needed), np.dtype("float16") if float16.
 
     Raises:
         ValueError: If the precision string is not recognized.
@@ -45,7 +45,7 @@ def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
     if embedding_precision == "float32":
         return None
     if embedding_precision == "float16":
-        return np.float16
+        return np.dtype(np.float16)
     raise ValueError(
         f"Unsupported embedding_precision={embedding_precision!r}. "
         f"Valid options: {_VALID_PRECISIONS}"
@@ -1776,6 +1776,9 @@ def save_features(
             Note: when aggregation_method="model", reduced precision affects the patch
             features fed into the slide encoder, which may impact inference quality.
     """
+    # Validate embedding_precision up-front so any ValueError surfaces before other logic.
+    _parse_feature_dtype(embedding_precision)
+
     # Auto-set aggregation_method to "model" if slide_model_type is specified
     if slide_model_type is not None and aggregation_method == "identity":
         logger.info(

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -31,6 +31,21 @@ logger = logging.getLogger(__name__)
 _VALID_PRECISIONS = ("float32", "float16", "bfloat16")
 
 
+def _numpy_to_torch(arr: np.ndarray, dtype: Optional[np.dtype] = None) -> torch.Tensor:
+    """Convert a numpy feature array to a torch tensor.
+
+    Handles ml_dtypes.bfloat16 arrays (which torch.from_numpy cannot convert
+    directly) by reinterpreting the raw uint16 bytes as torch.bfloat16.
+    When reading bfloat16 back from HDF5, h5py returns a |V2 (2-byte void) array;
+    pass ``dtype=np.dtype(ml_dtypes.bfloat16)`` to reinterpret it correctly.
+    """
+    if dtype is not None and dtype == np.dtype(ml_dtypes.bfloat16) and arr.dtype.kind == "V":
+        arr = arr.view(ml_dtypes.bfloat16)
+    if arr.dtype == np.dtype(ml_dtypes.bfloat16):
+        return torch.from_numpy(arr.view(np.uint16)).view(torch.bfloat16)
+    return torch.from_numpy(arr)
+
+
 def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
     """Parse embedding precision string into a numpy dtype, or None for float32 (no-op).
 
@@ -1397,7 +1412,7 @@ def aggregate_slide_features_batch(
                     # Save to PyTorch if requested
                     if output_pt:
                         logger.info(f"Saving aggregated features to {output_pt}")
-                        features_tensor = torch.from_numpy(aggregated_features)
+                        features_tensor = _numpy_to_torch(aggregated_features)
                         save_torch_tensor(output_pt, features_tensor)
 
                     successful_slides.append(slide_name)
@@ -1601,7 +1616,7 @@ def aggregate_slide_features_batch(
 
                 # Save to PyTorch if requested
                 if output_pt_paths and output_pt_paths[i] is not None:
-                    features_tensor = torch.from_numpy(aggregated_features)
+                    features_tensor = _numpy_to_torch(aggregated_features)
                     save_torch_tensor(output_pt_paths[i], features_tensor)
             except Exception as e:
                 logger.error(f"Failed to save results for slide {slide_name}: {str(e)}")
@@ -1713,7 +1728,7 @@ def aggregate_slide_features(
         # Save to PyTorch if requested
         if output_pt_path is not None:
             logger.info(f"Saving aggregated features to {output_pt_path}")
-            features_tensor = torch.from_numpy(aggregated_features)
+            features_tensor = _numpy_to_torch(aggregated_features)
             save_torch_tensor(output_pt_path, features_tensor)
 
     return output_h5_path, output_pt_path
@@ -1937,7 +1952,7 @@ def save_features(
                 logger.info(f"features size: {features.shape} ")
                 # logger.info(f'coordinates size: {file["coords"].shape} ')
 
-                features = torch.from_numpy(features)
+                features = _numpy_to_torch(features, dtype=feature_dtype)
                 save_torch_tensor(output_pt_path, features)
 
 

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -27,6 +27,30 @@ from .timer import timed
 
 logger = logging.getLogger(__name__)
 
+_VALID_PRECISIONS = ("float32", "float16")
+
+
+def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
+    """Parse embedding precision string into a numpy dtype, or None for float32 (no-op).
+
+    Args:
+        embedding_precision: One of "float32" or "float16".
+
+    Returns:
+        None if float32 (no cast needed), np.float16 if float16.
+
+    Raises:
+        ValueError: If the precision string is not recognized.
+    """
+    if embedding_precision == "float32":
+        return None
+    if embedding_precision == "float16":
+        return np.float16
+    raise ValueError(
+        f"Unsupported embedding_precision={embedding_precision!r}. "
+        f"Valid options: {_VALID_PRECISIONS}"
+    )
+
 
 def _make_dataloader(
     dataset,
@@ -100,6 +124,7 @@ class DatasetProcessor(ABC):
         output_h5_path: Optional[str] = None,
         patch_h5_path: Optional[str] = None,
         is_test_run: bool = False,
+        feature_dtype: Optional[np.dtype] = None,
     ) -> FeatureExtractionResult:
         """Process a dataset and extract features.
 
@@ -110,6 +135,8 @@ class DatasetProcessor(ABC):
             output_h5_path: Optional path to save features to HDF5.
             patch_h5_path: Optional path to source H5 for copying attributes.
             is_test_run: If True, only process first 3 batches.
+            feature_dtype: Optional numpy dtype to cast features to (e.g. np.float16).
+                None means no cast (float32 default from models).
 
         Returns:
             FeatureExtractionResult containing features and metadata.
@@ -132,6 +159,7 @@ class TileCoordProcessor(DatasetProcessor):
         output_h5_path: Optional[str] = None,
         patch_h5_path: Optional[str] = None,
         is_test_run: bool = False,
+        feature_dtype: Optional[np.dtype] = None,
     ) -> FeatureExtractionResult:
         """Process WholeSlideImageTileCoordDataset to extract features.
 
@@ -142,6 +170,7 @@ class TileCoordProcessor(DatasetProcessor):
             output_h5_path: Unused (features returned in memory).
             patch_h5_path: Unused.
             is_test_run: If True, only process first 3 batches.
+            feature_dtype: Optional numpy dtype to cast features to. None means no cast.
 
         Returns:
             FeatureExtractionResult with features and labels arrays.
@@ -162,6 +191,9 @@ class TileCoordProcessor(DatasetProcessor):
         features = np.concatenate(all_features, axis=0)
         labels = np.concatenate(all_labels, axis=0)
 
+        if feature_dtype is not None:
+            features = features.astype(feature_dtype)
+
         return FeatureExtractionResult(features=features, labels=labels)
 
 
@@ -180,6 +212,7 @@ class H5DatasetProcessor(DatasetProcessor):
         output_h5_path: Optional[str] = None,
         patch_h5_path: Optional[str] = None,
         is_test_run: bool = False,
+        feature_dtype: Optional[np.dtype] = None,
     ) -> FeatureExtractionResult:
         """Process WholeSlideImageH5Dataset to extract features and save to HDF5.
 
@@ -190,6 +223,9 @@ class H5DatasetProcessor(DatasetProcessor):
             output_h5_path: Path to save extracted features (required).
             patch_h5_path: Path to source H5 for copying attributes.
             is_test_run: If True, only process first 3 batches.
+            feature_dtype: Optional numpy dtype to cast features to before saving.
+                Cast is applied per-batch so the HDF5 dataset dtype is fixed from the
+                first write. None means no cast (float32 default from models).
 
         Returns:
             FeatureExtractionResult with features, coords, and output path.
@@ -218,6 +254,8 @@ class H5DatasetProcessor(DatasetProcessor):
                 continue
 
             features = model_fun(batch).numpy()
+            if feature_dtype is not None:
+                features = features.astype(feature_dtype)
             all_features.append(features)
             all_coords.append(coords)
 
@@ -226,8 +264,9 @@ class H5DatasetProcessor(DatasetProcessor):
             mode = "a"
 
         # Concatenate all results
+        empty_dtype = feature_dtype if feature_dtype is not None else np.float32
         features = (
-            np.concatenate(all_features, axis=0) if all_features else np.array([])
+            np.concatenate(all_features, axis=0) if all_features else np.array([], dtype=empty_dtype)
         )
         coords = np.concatenate(all_coords, axis=0) if all_coords else np.array([])
 
@@ -253,6 +292,7 @@ class ImageFolderProcessor(DatasetProcessor):
         output_h5_path: Optional[str] = None,
         patch_h5_path: Optional[str] = None,
         is_test_run: bool = False,
+        feature_dtype: Optional[np.dtype] = None,
     ) -> FeatureExtractionResult:
         """Process ImageFolder or FlatImageDataset to extract features.
 
@@ -263,6 +303,9 @@ class ImageFolderProcessor(DatasetProcessor):
             output_h5_path: Path to save extracted features (required).
             patch_h5_path: Unused.
             is_test_run: If True, only process first 3 batches.
+            feature_dtype: Optional numpy dtype to cast features to before saving.
+                Cast is applied per-batch so the HDF5 dataset dtype is fixed from the
+                first write. None means no cast (float32 default from models).
 
         Returns:
             FeatureExtractionResult with features, labels, and output path.
@@ -306,6 +349,8 @@ class ImageFolderProcessor(DatasetProcessor):
 
             labels_np = labels.numpy()
             features = model_fun(batch).numpy()
+            if feature_dtype is not None:
+                features = features.astype(feature_dtype)
 
             all_features.append(features)
             all_labels.append(labels_np)
@@ -314,8 +359,9 @@ class ImageFolderProcessor(DatasetProcessor):
             save_hdf5(output_h5_path, asset_dict, attr_h5_path=None, mode="a")
 
         # Concatenate all results
+        empty_dtype = feature_dtype if feature_dtype is not None else np.float32
         features = (
-            np.concatenate(all_features, axis=0) if all_features else np.array([])
+            np.concatenate(all_features, axis=0) if all_features else np.array([], dtype=empty_dtype)
         )
         labels = np.concatenate(all_labels, axis=0) if all_labels else np.array([])
 
@@ -382,6 +428,7 @@ def process_dataset(
     output_h5_path: Optional[str] = None,
     patch_h5_path: Optional[str] = None,
     is_test_run: bool = False,
+    feature_dtype: Optional[np.dtype] = None,
 ) -> FeatureExtractionResult:
     """Process a dataset to extract features.
 
@@ -402,6 +449,8 @@ def process_dataset(
         patch_h5_path: Optional path to source H5 for copying attributes.
             Used by H5DatasetProcessor.
         is_test_run: If True, only process first 3 batches (default: False).
+        feature_dtype: Optional numpy dtype to cast features to (e.g. np.float16).
+            None means no cast (float32 default from models).
 
     Returns:
         FeatureExtractionResult containing:
@@ -422,6 +471,7 @@ def process_dataset(
         output_h5_path=output_h5_path,
         patch_h5_path=patch_h5_path,
         is_test_run=is_test_run,
+        feature_dtype=feature_dtype,
     )
 
 
@@ -991,6 +1041,7 @@ def extract_patch_features(
     num_workers: int = 16,
     pin_memory: bool = True,
     is_test_run: bool = False,
+    embedding_precision: str = "float32",
 ) -> str:
     """Extract patch-level features from whole slide image (Step 1: Patch Encoding).
 
@@ -1013,6 +1064,9 @@ def extract_patch_features(
         num_workers: Number of worker processes for data loading (default: 16).
         pin_memory: Whether to pin memory for data loading (default: True).
         is_test_run: If True, only process first 3 batches (default: False).
+        embedding_precision: Numeric precision for saved patch embeddings.
+            "float32" (default) preserves full model precision; "float16" halves
+            storage size at the cost of reduced precision.
 
     Returns:
         Path to the output HDF5 file containing patch-level features.
@@ -1023,6 +1077,8 @@ def extract_patch_features(
     logger.info("Step 1: Extracting patch-level features")
     logger.info("loading model checkpoint")
     logger.info(f"Using batch_size={batch_size} for model {model_type}")
+
+    feature_dtype = _parse_feature_dtype(embedding_precision)
 
     model_factory = get_model_factory(model_type)
     if model_factory is None:
@@ -1092,6 +1148,7 @@ def extract_patch_features(
         patch_h5_path=patch_h5_path,
         output_h5_path=output_h5_path,
         is_test_run=is_test_run,
+        feature_dtype=feature_dtype,
     )
 
     logger.info(f"Patch-level features saved to {output_h5_path}")
@@ -1112,6 +1169,7 @@ def extract_patch_features_batch(
     num_workers=16,
     pin_memory=True,
     is_test_run=False,
+    embedding_precision="float32",
 ):
     """Extract patch-level features from multiple slides in batch mode.
 
@@ -1136,6 +1194,9 @@ def extract_patch_features_batch(
         num_workers: Number of worker processes for data loading (default: 16).
         pin_memory: Whether to pin memory for data loading (default: True).
         is_test_run: If True, only process first 3 batches per slide (default: False).
+        embedding_precision: Numeric precision for saved patch embeddings.
+            "float32" (default) preserves full model precision; "float16" halves
+            storage size at the cost of reduced precision.
 
     Returns:
         List of paths to output HDF5 files containing patch-level features.
@@ -1157,6 +1218,8 @@ def extract_patch_features_batch(
 
     if gpu_device_ids:
         gpu_device_id = gpu_device_ids
+
+    feature_dtype = _parse_feature_dtype(embedding_precision)
 
     # Resolve model_path from model_dir if provided
     if model_path is None and model_dir is not None:
@@ -1209,6 +1272,7 @@ def extract_patch_features_batch(
             patch_h5_path=patch_h5_path,
             output_h5_path=output_h5_path,
             is_test_run=is_test_run,
+            feature_dtype=feature_dtype,
         )
 
         logger.info(f"Patch-level features saved to {output_h5_path}")
@@ -1673,6 +1737,7 @@ def save_features(
     aggregation_method: str = "identity",
     slide_model_type: Optional[ModelType] = None,
     slide_model_path: Optional[str] = None,
+    embedding_precision: str = "float32",
 ) -> tuple[str, Optional[str]]:
     """Extract features from whole slide image and save to HDF5 and PyTorch formats.
 
@@ -1705,6 +1770,11 @@ def save_features(
             The required patch encoder will be automatically inferred and used. For example,
             specifying GIGAPATH_SLIDE will automatically use GIGAPATH as the patch encoder.
         slide_model_path: Optional path to slide encoder model weights.
+        embedding_precision: Numeric precision for saved patch embeddings.
+            "float32" (default) preserves full model precision; "float16" halves
+            storage size at the cost of reduced precision.
+            Note: when aggregation_method="model", reduced precision affects the patch
+            features fed into the slide encoder, which may impact inference quality.
     """
     # Auto-set aggregation_method to "model" if slide_model_type is specified
     if slide_model_type is not None and aggregation_method == "identity":
@@ -1720,6 +1790,13 @@ def save_features(
     if use_two_step:
         # Two-step process: patch encoding -> slide aggregation
         logger.info("Using two-step feature extraction process")
+
+        if aggregation_method == "model" and embedding_precision != "float32":
+            logger.warning(
+                f"embedding_precision={embedding_precision!r} with aggregation_method='model': "
+                "reduced-precision patch features will be fed to the slide encoder, "
+                "which may impact inference quality."
+            )
 
         # Auto-infer patch encoder from slide encoder if using model-based aggregation
         if aggregation_method == "model" and slide_model_type is not None:
@@ -1753,6 +1830,7 @@ def save_features(
             num_workers=num_workers,
             pin_memory=pin_memory,
             is_test_run=is_test_run,
+            embedding_precision=embedding_precision,
         )
 
         # Step 2: Aggregate to slide level
@@ -1773,6 +1851,8 @@ def save_features(
             gpu_device_id = gpu_device_ids
 
         logger.info("loading model checkpoint")
+
+        feature_dtype = _parse_feature_dtype(embedding_precision)
 
         model_factory = get_model_factory(model_type)
         if model_factory is None:
@@ -1842,6 +1922,7 @@ def save_features(
             patch_h5_path=patch_h5_path,
             output_h5_path=output_h5_path,
             is_test_run=is_test_run,
+            feature_dtype=feature_dtype,
         )
 
         if output_pt_path is not None:

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1330,6 +1330,7 @@ def aggregate_slide_features_batch(
     gpu_device_ids=None,
     slide_batch_size=8,
     max_slide_patches=None,
+    embedding_precision="float32",
 ):
     """Aggregate patch-level features to slide-level for multiple slides (Step 2: Batch Slide Encoding).
 
@@ -1360,6 +1361,9 @@ def aggregate_slide_features_batch(
             When a slide exceeds this limit, patches are randomly subsampled before encoding.
             Useful for TITAN whose alibi attention is O(N²) and OOMs on very large slides.
             None (default) disables subsampling.
+        embedding_precision: Numeric precision for saved slide embeddings ("float32",
+            "float16", or "bfloat16"). Default "float32". Applied to the aggregated
+            output before saving; input patch features are always read as-is.
 
     Returns:
         Tuple of (output_h5_paths, output_pt_paths) if saving.
@@ -1412,10 +1416,13 @@ def aggregate_slide_features_batch(
                         patch_size=patch_size,
                     )
 
+                    feature_dtype = _parse_feature_dtype(embedding_precision)
+                    features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+
                     # Save to HDF5 if requested
                     if output_h5:
                         logger.info(f"Saving aggregated features to {output_h5}")
-                        asset_dict = {"features": aggregated_features}
+                        asset_dict = {"features": features_to_save}
 
                         # Copy coordinates if they exist and we're using identity
                         if aggregation_method == "identity" and "coords" in file:
@@ -1426,7 +1433,7 @@ def aggregate_slide_features_batch(
                     # Save to PyTorch if requested
                     if output_pt:
                         logger.info(f"Saving aggregated features to {output_pt}")
-                        features_tensor = _numpy_to_torch(aggregated_features)
+                        features_tensor = _numpy_to_torch(features_to_save)
                         save_torch_tensor(output_pt, features_tensor)
 
                     successful_slides.append(slide_name)
@@ -1635,16 +1642,19 @@ def aggregate_slide_features_batch(
                 continue
 
             try:
+                feature_dtype = _parse_feature_dtype(embedding_precision)
+                features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+
                 # Save to HDF5 if requested
                 if output_h5_paths and output_h5_paths[i] is not None:
-                    asset_dict = {"features": aggregated_features}
+                    asset_dict = {"features": features_to_save}
                     save_hdf5(
                         output_h5_paths[i], asset_dict, attr_h5_path=None, mode="w"
                     )
 
                 # Save to PyTorch if requested
                 if output_pt_paths and output_pt_paths[i] is not None:
-                    features_tensor = _numpy_to_torch(aggregated_features)
+                    features_tensor = _numpy_to_torch(features_to_save)
                     save_torch_tensor(output_pt_paths[i], features_tensor)
             except Exception as e:
                 logger.error(f"Failed to save results for slide {slide_name}: {str(e)}")
@@ -1689,6 +1699,7 @@ def aggregate_slide_features(
     use_gpu: bool = True,
     gpu_device_id: Optional[Union[int, List[int]]] = None,
     gpu_device_ids: Optional[List[int]] = None,
+    embedding_precision: str = "float32",
 ) -> Union[tuple[Optional[str], Optional[str]], np.ndarray]:
     """Aggregate patch-level features to slide-level (Step 2: Slide Encoding).
 
@@ -1710,6 +1721,9 @@ def aggregate_slide_features(
         use_gpu: Whether to use GPU for model-based aggregation (default: True).
         gpu_device_id: GPU device ID to use.
         gpu_device_ids: List of GPU device IDs for multi-GPU.
+        embedding_precision: Numeric precision for saved slide embeddings ("float32",
+            "float16", or "bfloat16"). Default "float32". Cast is applied to the
+            aggregated output before saving; input patch features are read as-is.
 
     Returns:
         Tuple of (output_h5_path, output_pt_path) if saving, otherwise features tensor.
@@ -1742,10 +1756,13 @@ def aggregate_slide_features(
             patch_size=patch_size,
         )
 
+        feature_dtype = _parse_feature_dtype(embedding_precision)
+        features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+
         # Save to HDF5 if requested
         if output_h5_path is not None:
             logger.info(f"Saving aggregated features to {output_h5_path}")
-            asset_dict = {"features": aggregated_features}
+            asset_dict = {"features": features_to_save}
 
             # Copy coordinates if they exist and we're using identity
             if aggregation_method == "identity" and "coords" in file:
@@ -1756,7 +1773,7 @@ def aggregate_slide_features(
         # Save to PyTorch if requested
         if output_pt_path is not None:
             logger.info(f"Saving aggregated features to {output_pt_path}")
-            features_tensor = _numpy_to_torch(aggregated_features)
+            features_tensor = _numpy_to_torch(features_to_save)
             save_torch_tensor(output_pt_path, features_tensor)
 
     return output_h5_path, output_pt_path
@@ -1840,13 +1857,6 @@ def save_features(
         # Two-step process: patch encoding -> slide aggregation
         logger.info("Using two-step feature extraction process")
 
-        if aggregation_method == "model" and embedding_precision != "float32":
-            logger.warning(
-                f"embedding_precision={embedding_precision!r} with aggregation_method='model': "
-                "reduced-precision patch features will be fed to the slide encoder, "
-                "which may impact inference quality."
-            )
-
         # Auto-infer patch encoder from slide encoder if using model-based aggregation
         if aggregation_method == "model" and slide_model_type is not None:
             required_patch_encoder = get_required_patch_encoder(slide_model_type)
@@ -1863,7 +1873,7 @@ def save_features(
         if intermediate_h5_path is None:
             intermediate_h5_path = str(Path(output_h5_path).with_suffix(".patch.h5"))
 
-        # Step 1: Extract patch-level features
+        # Step 1: Extract patch-level features — always float32 (intermediate for slide encoder)
         extract_patch_features(
             patch_h5_path=patch_h5_path,
             slide_path=slide_path,
@@ -1879,10 +1889,10 @@ def save_features(
             num_workers=num_workers,
             pin_memory=pin_memory,
             is_test_run=is_test_run,
-            embedding_precision=embedding_precision,
+            embedding_precision="float32",
         )
 
-        # Step 2: Aggregate to slide level
+        # Step 2: Aggregate to slide level — apply embedding_precision to final output
         aggregate_slide_features(
             patch_features_h5_path=intermediate_h5_path,
             output_h5_path=output_h5_path,
@@ -1893,6 +1903,7 @@ def save_features(
             use_gpu=use_gpu,
             gpu_device_id=gpu_device_id,
             gpu_device_ids=gpu_device_ids,
+            embedding_precision=embedding_precision,
         )
     else:
         # Single-step process (backward compatible)

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
 import h5py
+import ml_dtypes
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
@@ -27,17 +28,17 @@ from .timer import timed
 
 logger = logging.getLogger(__name__)
 
-_VALID_PRECISIONS = ("float32", "float16")
+_VALID_PRECISIONS = ("float32", "float16", "bfloat16")
 
 
 def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
     """Parse embedding precision string into a numpy dtype, or None for float32 (no-op).
 
     Args:
-        embedding_precision: One of "float32" or "float16".
+        embedding_precision: One of "float32", "float16", or "bfloat16".
 
     Returns:
-        None if float32 (no cast needed), np.dtype("float16") if float16.
+        None if float32 (no cast needed), otherwise the corresponding np.dtype.
 
     Raises:
         ValueError: If the precision string is not recognized.
@@ -46,6 +47,8 @@ def _parse_feature_dtype(embedding_precision: str) -> Optional[np.dtype]:
         return None
     if embedding_precision == "float16":
         return np.dtype(np.float16)
+    if embedding_precision == "bfloat16":
+        return np.dtype(ml_dtypes.bfloat16)
     raise ValueError(
         f"Unsupported embedding_precision={embedding_precision!r}. "
         f"Valid options: {_VALID_PRECISIONS}"
@@ -1066,7 +1069,7 @@ def extract_patch_features(
         is_test_run: If True, only process first 3 batches (default: False).
         embedding_precision: Numeric precision for saved patch embeddings.
             "float32" (default) preserves full model precision; "float16" halves
-            storage size at the cost of reduced precision.
+            storage size; "bfloat16" uses brain-float format.
 
     Returns:
         Path to the output HDF5 file containing patch-level features.
@@ -1196,7 +1199,7 @@ def extract_patch_features_batch(
         is_test_run: If True, only process first 3 batches per slide (default: False).
         embedding_precision: Numeric precision for saved patch embeddings.
             "float32" (default) preserves full model precision; "float16" halves
-            storage size at the cost of reduced precision.
+            storage size; "bfloat16" uses brain-float format.
 
     Returns:
         List of paths to output HDF5 files containing patch-level features.
@@ -1772,7 +1775,7 @@ def save_features(
         slide_model_path: Optional path to slide encoder model weights.
         embedding_precision: Numeric precision for saved patch embeddings.
             "float32" (default) preserves full model precision; "float16" halves
-            storage size at the cost of reduced precision.
+            storage size; "bfloat16" uses brain-float format.
             Note: when aggregation_method="model", reduced precision affects the patch
             features fed into the slide encoder, which may impact inference quality.
     """

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -664,10 +664,16 @@ def segment_tissue(
                 "Use overlap to derive step_size automatically, or pass step_size directly."
             )
 
-        # Get MPP with fallback handling
-        slide_mpp = get_slide_mpp(
+        # Get MPP with fallback handling.
+        # Probe without a default first to detect whether real metadata exists.
+        _mpp_probe = get_slide_mpp(
+            wsi, slide_path, default_mpp=None, slide_mpp_override=slide_mpp_override
+        )
+        slide_mpp = _mpp_probe if _mpp_probe is not None else get_slide_mpp(
             wsi, slide_path, slide_mpp_override=slide_mpp_override
         )
+        # True when no MPP metadata was found and the 0.5 µm/px default was used.
+        mpp_is_fallback = _mpp_probe is None and slide_mpp_override is None
 
         native_step_size = get_native_size(step_size, mpp, slide_mpp)
         native_patch_size = get_native_size(patch_size, mpp, slide_mpp)
@@ -852,6 +858,7 @@ def segment_tissue(
             "patch_level": 0,
             "mpp": mpp,
             "native_mpp": slide_mpp,
+            "mpp_is_fallback": mpp_is_fallback,
             "level_dim": wsi.level_dimensions[0],
             "name": slide_id,
             "overlap": overlap,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "sacremoses",
   "tqdm",
   "pyarrow>=23.0.1",
+  "ml-dtypes>=0.2",
 ]
 
 [dependency-groups]

--- a/tests/mussel/cli/test_extract_features.py
+++ b/tests/mussel/cli/test_extract_features.py
@@ -228,6 +228,58 @@ def test_auto_set_aggregation_method(tmp_path, use_gpu, num_workers):
 
 @pytest.mark.slow
 @pytest.mark.integration
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("embedding_precision", ["float16", "bfloat16"])
+def test_extract_features_two_step_intermediate_stays_float32(
+    tmp_path, test_data_path, patch_h5_path, use_gpu, num_workers, embedding_precision
+):
+    """E2E: in two-step mode the intermediate tile H5 must be float32 regardless of
+    embedding_precision; only the final slide output is cast to the requested precision."""
+    slide_path = os.path.join(test_data_path, "948176.svs")
+    output_h5_path = tmp_path / f"slide_{embedding_precision}.h5"
+    output_pt_path = tmp_path / f"slide_{embedding_precision}.pt"
+    intermediate_h5_path = tmp_path / f"intermediate_{embedding_precision}.patch.h5"
+
+    cfg = ExtractFeaturesConfig(
+        slide_path=slide_path,
+        patch_h5_path=patch_h5_path,
+        output_h5_path=str(output_h5_path),
+        output_pt_path=str(output_pt_path),
+        intermediate_h5_path=str(intermediate_h5_path),
+        num_workers=num_workers,
+        model_type=ModelType.RESNET50,
+        use_gpu=use_gpu,
+        aggregation_method="mean",
+        embedding_precision=embedding_precision,
+    )
+    mussel.cli.extract_features.main(OmegaConf.create(cfg))
+
+    assert output_h5_path.exists(), "Final slide H5 must exist"
+    assert intermediate_h5_path.exists(), "Intermediate tile H5 must exist"
+
+    # Intermediate tile features must be float32 (full precision for any downstream encoder)
+    with h5py.File(intermediate_h5_path, "r") as f:
+        assert f["features"].dtype == np.float32, (
+            f"Intermediate tile features must be float32, got {f['features'].dtype}"
+        )
+
+    # Final slide output must be at the requested reduced precision (2 bytes)
+    with h5py.File(output_h5_path, "r") as f:
+        assert f["features"].dtype.itemsize == 2, (
+            f"Final slide features should be 2-byte {embedding_precision}, "
+            f"got {f['features'].dtype}"
+        )
+
+    # PT file dtype must also match
+    pt_tensor = torch.load(output_pt_path, weights_only=True)
+    expected_torch_dtype = torch.float16 if embedding_precision == "float16" else torch.bfloat16
+    assert pt_tensor.dtype == expected_torch_dtype, (
+        f"Expected .pt dtype {expected_torch_dtype}, got {pt_tensor.dtype}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("embedding_precision", ["float16", "bfloat16"])
 def test_extract_features_embedding_precision(

--- a/tests/mussel/cli/test_extract_features.py
+++ b/tests/mussel/cli/test_extract_features.py
@@ -1,7 +1,11 @@
 import os
 import ssl
 
+import h5py
+import ml_dtypes
+import numpy as np
 import pytest
+import torch
 from omegaconf import OmegaConf
 
 import mussel.cli.extract_features
@@ -220,3 +224,49 @@ def test_auto_set_aggregation_method(tmp_path, use_gpu, num_workers):
         mock_aggregate.assert_called_once()
         call_kwargs = mock_aggregate.call_args[1]
         assert call_kwargs["aggregation_method"] == "model"
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("embedding_precision", ["float16", "bfloat16"])
+def test_extract_features_embedding_precision(
+    tmp_path, test_data_path, patch_h5_path, use_gpu, num_workers, embedding_precision
+):
+    """E2E: extract_features with float16/bfloat16 writes reduced-precision outputs."""
+    slide_path = os.path.join(test_data_path, "948176.svs")
+    output_h5_path = tmp_path / f"test_{embedding_precision}.h5"
+    output_pt_path = tmp_path / f"test_{embedding_precision}.pt"
+
+    cfg = ExtractFeaturesConfig(
+        slide_path=slide_path,
+        patch_h5_path=patch_h5_path,
+        output_h5_path=str(output_h5_path),
+        output_pt_path=str(output_pt_path),
+        num_workers=num_workers,
+        model_type=ModelType.RESNET50,
+        use_gpu=use_gpu,
+        embedding_precision=embedding_precision,
+    )
+    mussel.cli.extract_features.main(OmegaConf.create(cfg))
+
+    assert output_h5_path.exists()
+    assert output_pt_path.exists()
+
+    with h5py.File(output_h5_path, "r") as f:
+        assert "features" in f
+        assert f["features"].shape[0] > 0
+        # Both float16 and bfloat16 occupy 2 bytes per element.
+        assert f["features"].dtype.itemsize == 2, (
+            f"Expected 2-byte dtype for {embedding_precision}, "
+            f"got {f['features'].dtype}"
+        )
+
+    pt_tensor = torch.load(output_pt_path, weights_only=True)
+    assert pt_tensor.shape[0] > 0
+    expected_torch_dtype = (
+        torch.float16 if embedding_precision == "float16" else torch.bfloat16
+    )
+    assert pt_tensor.dtype == expected_torch_dtype, (
+        f"Expected .pt tensor dtype {expected_torch_dtype}, got {pt_tensor.dtype}"
+    )

--- a/tests/mussel/utils/test_feature_extract.py
+++ b/tests/mussel/utils/test_feature_extract.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import ml_dtypes
 import numpy as np
 import pytest
 
@@ -191,9 +192,13 @@ def test_parse_feature_dtype_float16():
     assert _parse_feature_dtype("float16") == np.dtype(np.float16)
 
 
+def test_parse_feature_dtype_bfloat16():
+    assert _parse_feature_dtype("bfloat16") == np.dtype(ml_dtypes.bfloat16)
+
+
 def test_parse_feature_dtype_invalid_raises():
     with pytest.raises(ValueError, match="Unsupported embedding_precision"):
-        _parse_feature_dtype("bfloat16")
+        _parse_feature_dtype("float8")
 
 
 def _make_h5_processor_inputs(feature_dim=4, n_patches=8, batch_size=4):
@@ -263,7 +268,6 @@ def test_h5_dataset_processor_default_float32():
 def test_tile_coord_processor_float16():
     """TileCoordProcessor with feature_dtype=np.float16 casts output after concat."""
     import torch
-    from unittest.mock import MagicMock
 
     batches = [(torch.zeros(4, 4), torch.zeros(4, dtype=torch.long))] * 2
     mock_dataset = MagicMock()
@@ -280,6 +284,53 @@ def test_tile_coord_processor_float16():
         feature_dtype=np.float16,
     )
     assert result.features.dtype == np.float16
+
+
+def test_h5_dataset_processor_saves_bfloat16():
+    """H5DatasetProcessor with bfloat16 keeps in-memory dtype; HDF5 stores as 2-byte void."""
+    import h5py
+
+    bfloat16 = np.dtype(ml_dtypes.bfloat16)
+    mock_dataset, mock_loader, mock_model_fun = _make_h5_processor_inputs()
+    processor = H5DatasetProcessor()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = os.path.join(tmpdir, "feats.h5")
+        result = processor.process(
+            dataset=mock_dataset,
+            loader=mock_loader,
+            model_fun=mock_model_fun,
+            output_h5_path=out_path,
+            is_test_run=False,
+            feature_dtype=bfloat16,
+        )
+        # In-memory result preserves bfloat16 dtype.
+        assert result.features.dtype == bfloat16
+        # h5py stores bfloat16 as a 2-byte opaque type (|V2); verify storage size.
+        with h5py.File(out_path, "r") as f:
+            assert f["features"].dtype.itemsize == 2
+
+
+def test_tile_coord_processor_bfloat16():
+    """TileCoordProcessor with feature_dtype=ml_dtypes.bfloat16 casts output after concat."""
+    import torch
+
+    bfloat16 = np.dtype(ml_dtypes.bfloat16)
+    batches = [(torch.zeros(4, 4), torch.zeros(4, dtype=torch.long))] * 2
+    mock_dataset = MagicMock()
+    mock_loader = batches
+
+    def mock_model_fun(batch):
+        return torch.zeros(len(batch), 4)
+
+    processor = TileCoordProcessor()
+    result = processor.process(
+        dataset=mock_dataset,
+        loader=mock_loader,
+        model_fun=mock_model_fun,
+        feature_dtype=bfloat16,
+    )
+    assert result.features.dtype == bfloat16
 
 
 def test_extract_features_config_has_embedding_precision_field():

--- a/tests/mussel/utils/test_feature_extract.py
+++ b/tests/mussel/utils/test_feature_extract.py
@@ -170,3 +170,128 @@ def test_compatibility_validated_with_preloaded_patch_model():
         )
 
     mock_validate.assert_called_once_with(ModelType.GIGAPATH, ModelType.GIGAPATH_SLIDE)
+
+
+# -- embedding precision tests -----------------------------------------------
+
+import tempfile
+import os
+
+import pytest
+import numpy as np
+
+from mussel.utils.feature_extract import (
+    _parse_feature_dtype,
+    H5DatasetProcessor,
+    TileCoordProcessor,
+    process_dataset,
+)
+from mussel.cli.extract_features import ExtractFeaturesConfig
+
+
+def test_parse_feature_dtype_float32_returns_none():
+    assert _parse_feature_dtype("float32") is None
+
+
+def test_parse_feature_dtype_float16():
+    assert _parse_feature_dtype("float16") == np.float16
+
+
+def test_parse_feature_dtype_invalid_raises():
+    with pytest.raises(ValueError, match="Unsupported embedding_precision"):
+        _parse_feature_dtype("bfloat16")
+
+
+def _make_h5_processor_inputs(feature_dim=4, n_patches=8, batch_size=4):
+    """Return (mock_dataset, mock_loader, mock_model_fun) for H5DatasetProcessor tests."""
+    import torch
+    from unittest.mock import MagicMock
+
+    batches = []
+    n_batches = n_patches // batch_size
+    for _ in range(n_batches):
+        features_tensor = torch.zeros(batch_size, feature_dim)
+        coords_np = np.zeros((batch_size, 2), dtype=np.int32)
+        batches.append((features_tensor, coords_np))
+
+    mock_dataset = MagicMock()
+    mock_dataset.__class__.__name__ = "WholeSlideImageH5Dataset"
+    mock_loader = batches
+
+    def mock_model_fun(batch):
+        return torch.zeros(len(batch), feature_dim)
+
+    return mock_dataset, mock_loader, mock_model_fun
+
+
+def test_h5_dataset_processor_saves_float16():
+    """H5DatasetProcessor with feature_dtype=np.float16 writes float16 to HDF5."""
+    import h5py
+
+    mock_dataset, mock_loader, mock_model_fun = _make_h5_processor_inputs()
+    processor = H5DatasetProcessor()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = os.path.join(tmpdir, "feats.h5")
+        result = processor.process(
+            dataset=mock_dataset,
+            loader=mock_loader,
+            model_fun=mock_model_fun,
+            output_h5_path=out_path,
+            is_test_run=False,
+            feature_dtype=np.float16,
+        )
+        assert result.features.dtype == np.float16
+        with h5py.File(out_path, "r") as f:
+            assert f["features"].dtype == np.float16
+
+
+def test_h5_dataset_processor_default_float32():
+    """H5DatasetProcessor with feature_dtype=None keeps float32."""
+    import h5py
+
+    mock_dataset, mock_loader, mock_model_fun = _make_h5_processor_inputs()
+    processor = H5DatasetProcessor()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = os.path.join(tmpdir, "feats.h5")
+        result = processor.process(
+            dataset=mock_dataset,
+            loader=mock_loader,
+            model_fun=mock_model_fun,
+            output_h5_path=out_path,
+            is_test_run=False,
+            feature_dtype=None,
+        )
+        assert result.features.dtype == np.float32
+        with h5py.File(out_path, "r") as f:
+            assert f["features"].dtype == np.float32
+
+
+def test_tile_coord_processor_float16():
+    """TileCoordProcessor with feature_dtype=np.float16 casts output after concat."""
+    import torch
+    from unittest.mock import MagicMock
+
+    batches = [(torch.zeros(4, 4), torch.zeros(4, dtype=torch.long))] * 2
+    mock_dataset = MagicMock()
+    mock_loader = batches
+
+    def mock_model_fun(batch):
+        return torch.zeros(len(batch), 4)
+
+    processor = TileCoordProcessor()
+    result = processor.process(
+        dataset=mock_dataset,
+        loader=mock_loader,
+        model_fun=mock_model_fun,
+        feature_dtype=np.float16,
+    )
+    assert result.features.dtype == np.float16
+
+
+def test_extract_features_config_has_embedding_precision_field():
+    """ExtractFeaturesConfig must include embedding_precision defaulting to float32."""
+    cfg = ExtractFeaturesConfig()
+    assert hasattr(cfg, "embedding_precision")
+    assert cfg.embedding_precision == "float32"

--- a/tests/mussel/utils/test_feature_extract.py
+++ b/tests/mussel/utils/test_feature_extract.py
@@ -338,3 +338,146 @@ def test_extract_features_config_has_embedding_precision_field():
     cfg = ExtractFeaturesConfig()
     assert hasattr(cfg, "embedding_precision")
     assert cfg.embedding_precision == "float32"
+
+
+# -- slide pipeline precision semantics ----------------------------------------
+
+def test_aggregate_slide_features_precision():
+    """aggregate_slide_features saves output at the requested precision."""
+    import h5py
+    import tempfile
+    from mussel.utils.feature_extract import aggregate_slide_features
+
+    features = np.random.rand(10, 8).astype(np.float32)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        patch_h5 = os.path.join(tmpdir, "patches.h5")
+        with h5py.File(patch_h5, "w") as f:
+            f.create_dataset("features", data=features)
+
+        for precision, expected_itemsize, expected_kind in [
+            ("float32", 4, "f"),
+            ("float16", 2, "f"),
+            ("bfloat16", 2, "V"),
+        ]:
+            out_h5 = os.path.join(tmpdir, f"slide_{precision}.h5")
+            aggregate_slide_features(
+                patch_features_h5_path=patch_h5,
+                output_h5_path=out_h5,
+                aggregation_method="mean",
+                embedding_precision=precision,
+            )
+            with h5py.File(out_h5, "r") as f:
+                dtype = f["features"].dtype
+                assert dtype.itemsize == expected_itemsize, (
+                    f"precision={precision}: expected itemsize {expected_itemsize}, got {dtype.itemsize}"
+                )
+                if expected_kind != "V":
+                    assert dtype.kind == expected_kind, (
+                        f"precision={precision}: expected kind {expected_kind!r}, got {dtype.kind!r}"
+                    )
+
+
+def test_save_features_two_step_keeps_intermediate_float32():
+    """In two-step (slide model) path, intermediate tile features must remain float32."""
+    import h5py
+    import tempfile
+    from mussel.utils.feature_extract import _parse_feature_dtype, save_features
+
+    features = np.random.rand(4, 8).astype(np.float32)
+    coords = np.zeros((4, 2), dtype=np.int32)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        patch_h5 = os.path.join(tmpdir, "patches.h5")
+        with h5py.File(patch_h5, "w") as f:
+            f.create_dataset("features", data=features)
+            f.create_dataset("coords", data=coords)
+            f["features"].attrs["patch_size"] = 256
+            f["features"].attrs["patch_level"] = 0
+            f["features"].attrs["patch_size_to_resize_to_for_desired_mpp"] = 224
+
+        intermediate_calls = []
+
+        def fake_extract_patch(patch_h5_path, slide_path, output_h5_path, embedding_precision="float32", **kwargs):
+            intermediate_calls.append(embedding_precision)
+            with h5py.File(patch_h5_path, "r") as src, h5py.File(output_h5_path, "w") as dst:
+                dst.create_dataset("features", data=src["features"][:])
+                dst.create_dataset("coords", data=src["coords"][:])
+
+        def fake_aggregate(patch_features_h5_path, output_h5_path, embedding_precision="float32", **kwargs):
+            feature_dtype = _parse_feature_dtype(embedding_precision)
+            with h5py.File(patch_features_h5_path, "r") as src:
+                data = src["features"][:]
+            if feature_dtype is not None:
+                data = data.astype(feature_dtype)
+            if output_h5_path:
+                with h5py.File(output_h5_path, "w") as dst:
+                    dst.create_dataset("features", data=data)
+            return output_h5_path, None
+
+        out_h5 = os.path.join(tmpdir, "slide_out.h5")
+
+        with patch("mussel.utils.feature_extract.extract_patch_features", side_effect=fake_extract_patch), \
+             patch("mussel.utils.feature_extract.aggregate_slide_features", side_effect=fake_aggregate):
+            save_features(
+                patch_h5_path=patch_h5,
+                slide_path="dummy.svs",
+                output_h5_path=out_h5,
+                aggregation_method="model",
+                embedding_precision="float16",
+            )
+
+        assert intermediate_calls == ["float32"], (
+            f"Intermediate tile extraction must use float32, got {intermediate_calls}"
+        )
+        with h5py.File(out_h5, "r") as f:
+            assert f["features"].dtype.itemsize == 2
+            assert f["features"].dtype.kind == "f"  # float16
+
+
+def test_aggregate_slide_features_batch_precision():
+    """aggregate_slide_features_batch casts output to the requested precision."""
+    import h5py
+    import tempfile
+    from mussel.utils.feature_extract import aggregate_slide_features_batch
+
+    features = np.random.rand(6, 8).astype(np.float32)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        patch_h5 = os.path.join(tmpdir, "patches.h5")
+        with h5py.File(patch_h5, "w") as f:
+            f.create_dataset("features", data=features)
+
+        out_h5 = os.path.join(tmpdir, "out.h5")
+
+        aggregate_slide_features_batch(
+            patch_features_h5_paths=[patch_h5],
+            output_h5_paths=[out_h5],
+            aggregation_method="mean",
+            embedding_precision="float16",
+        )
+
+        with h5py.File(out_h5, "r") as f:
+            assert f["features"].dtype.itemsize == 2
+            assert f["features"].dtype.kind == "f"
+
+
+def test_aggregate_slide_features_config_has_embedding_precision():
+    """AggregateSlideFeaturesConfig must expose embedding_precision."""
+    from mussel.cli.aggregate_slide_features import AggregateSlideFeaturesConfig
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.structured(AggregateSlideFeaturesConfig)
+    assert hasattr(cfg, "embedding_precision")
+    assert cfg.embedding_precision == "float32"
+
+
+def test_tessellate_extract_features_config_has_embedding_precision():
+    """TessellateExtractFeaturesConfig must expose embedding_precision."""
+    from mussel.cli.tessellate_extract_features import TessellateExtractFeaturesConfig
+    from mussel.cli.tessellate import SegConfig
+    from omegaconf import OmegaConf
+
+    cfg = TessellateExtractFeaturesConfig(seg_config=SegConfig())
+    assert hasattr(cfg, "embedding_precision")
+    assert cfg.embedding_precision == "float32"

--- a/tests/mussel/utils/test_feature_extract.py
+++ b/tests/mussel/utils/test_feature_extract.py
@@ -1,12 +1,20 @@
 """Tests for get_features pre-loaded model parameters."""
 
+import os
+import tempfile
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
+from mussel.cli.extract_features import ExtractFeaturesConfig
 from mussel.models import ModelType
-from mussel.utils.feature_extract import get_features
+from mussel.utils.feature_extract import (
+    H5DatasetProcessor,
+    TileCoordProcessor,
+    _parse_feature_dtype,
+    get_features,
+)
 
 
 def _make_mock_model(feature_dim=384):
@@ -174,27 +182,13 @@ def test_compatibility_validated_with_preloaded_patch_model():
 
 # -- embedding precision tests -----------------------------------------------
 
-import tempfile
-import os
-
-import pytest
-import numpy as np
-
-from mussel.utils.feature_extract import (
-    _parse_feature_dtype,
-    H5DatasetProcessor,
-    TileCoordProcessor,
-    process_dataset,
-)
-from mussel.cli.extract_features import ExtractFeaturesConfig
-
 
 def test_parse_feature_dtype_float32_returns_none():
     assert _parse_feature_dtype("float32") is None
 
 
 def test_parse_feature_dtype_float16():
-    assert _parse_feature_dtype("float16") == np.float16
+    assert _parse_feature_dtype("float16") == np.dtype(np.float16)
 
 
 def test_parse_feature_dtype_invalid_raises():
@@ -205,7 +199,6 @@ def test_parse_feature_dtype_invalid_raises():
 def _make_h5_processor_inputs(feature_dim=4, n_patches=8, batch_size=4):
     """Return (mock_dataset, mock_loader, mock_model_fun) for H5DatasetProcessor tests."""
     import torch
-    from unittest.mock import MagicMock
 
     batches = []
     n_batches = n_patches // batch_size
@@ -215,7 +208,6 @@ def _make_h5_processor_inputs(feature_dim=4, n_patches=8, batch_size=4):
         batches.append((features_tensor, coords_np))
 
     mock_dataset = MagicMock()
-    mock_dataset.__class__.__name__ = "WholeSlideImageH5Dataset"
     mock_loader = batches
 
     def mock_model_fun(batch):

--- a/uv.lock
+++ b/uv.lock
@@ -2168,7 +2168,7 @@ wheels = [
 
 [[package]]
 name = "mussel"
-version = "1.3.0"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "configargparse" },
@@ -2180,6 +2180,7 @@ dependencies = [
     { name = "h5py" },
     { name = "hydra-core" },
     { name = "matplotlib" },
+    { name = "ml-dtypes" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "pandas" },
@@ -2319,6 +2320,7 @@ requires-dist = [
     { name = "keras", marker = "extra == 'tensorflow-gpu'" },
     { name = "lifelines", marker = "extra == 'fastattn'" },
     { name = "matplotlib" },
+    { name = "ml-dtypes", specifier = ">=0.2" },
     { name = "ninja", marker = "extra == 'fastattn'", specifier = "==1.11.1.1" },
     { name = "numpy" },
     { name = "ome-zarr", marker = "extra == 'zarr'" },
@@ -5363,10 +5365,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:269b10c34430aa8e9643dbe035dc525c4a9b1d671cd3dbc8ecbcaed280ae322d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:23d062bf70776a3d04dbe74db950db2a5245e1ba4f27208a87f0d743b0d06e86" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b3203f191bc40783c99488d2e776dcf93ac431a59491d627a1ca5b3ae20b22" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:31f8c39660962f9ae4eeec995e3049b5492eb7360dd4f07377658ef4d728fa4c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:269b10c34430aa8e9643dbe035dc525c4a9b1d671cd3dbc8ecbcaed280ae322d", upload-time = "2024-10-29T23:01:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:23d062bf70776a3d04dbe74db950db2a5245e1ba4f27208a87f0d743b0d06e86", upload-time = "2024-10-29T23:02:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b3203f191bc40783c99488d2e776dcf93ac431a59491d627a1ca5b3ae20b22", upload-time = "2024-10-29T23:02:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:31f8c39660962f9ae4eeec995e3049b5492eb7360dd4f07377658ef4d728fa4c", upload-time = "2024-10-29T23:02:11Z" },
 ]
 
 [[package]]
@@ -5388,10 +5390,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:7f91a2200e352745d70e22396bd501448e28350fbdbd8d8b1c83037e25451150" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:df93157482b672892d29134d3fae9d38ba3219702faedd79f407eb36774c56ce" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:07d7c9e069123d5af08b0cf0013d74f680b2d8be7d9e2cf561a52c90c55d9409" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:81531d4d5ca74163dc9574b87396531e546a60cceb6253303c7db6a21e867fdf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:7f91a2200e352745d70e22396bd501448e28350fbdbd8d8b1c83037e25451150", upload-time = "2024-10-29T23:00:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:df93157482b672892d29134d3fae9d38ba3219702faedd79f407eb36774c56ce", upload-time = "2024-10-29T23:00:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:07d7c9e069123d5af08b0cf0013d74f680b2d8be7d9e2cf561a52c90c55d9409", upload-time = "2024-10-29T23:00:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:81531d4d5ca74163dc9574b87396531e546a60cceb6253303c7db6a21e867fdf", upload-time = "2024-10-29T23:01:02Z" },
 ]
 
 [[package]]
@@ -5431,10 +5433,10 @@ dependencies = [
     { name = "typing-extensions", marker = "(extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra != 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra != 'extra-6-mussel-fastattn' and extra != 'extra-6-mussel-tensorflow-cpu' and extra != 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:9b22d6d98aa56f9317902dec0e066814a6edba1aada90110ceea2bb0678df22f" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:c8ab8c92eab928a93c483f83ca8c63f13dafc10fc93ad90ed2dcb7c82ea50410" },
-    { url = "https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:4bcee18f00c43c815efad8efaa3bca584ffdc8d2cd35ef4c44c814f2739d9191" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14", upload-time = "2024-10-29T23:15:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:9b22d6d98aa56f9317902dec0e066814a6edba1aada90110ceea2bb0678df22f", upload-time = "2024-10-29T23:16:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:c8ab8c92eab928a93c483f83ca8c63f13dafc10fc93ad90ed2dcb7c82ea50410", upload-time = "2024-10-29T23:18:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:4bcee18f00c43c815efad8efaa3bca584ffdc8d2cd35ef4c44c814f2739d9191", upload-time = "2024-10-29T23:18:42Z" },
 ]
 
 [[package]]
@@ -5473,12 +5475,12 @@ dependencies = [
     { name = "typing-extensions", marker = "extra == 'extra-6-mussel-fastattn' or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:114d1cbab7de92bad7f7767d83b3e1bff2016331964d26c90a5f9a38b80b58a6", upload-time = "2026-04-27T20:46:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6f17bf3cc27463f0a0a9dd8e2312737551833948ca24099264bfed7295ad3669", upload-time = "2026-04-27T20:46:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:d0bd014a512f6e12ede57857d4c9a07056104c983b4a703672e9e4114f0bf414", upload-time = "2026-04-27T20:48:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:36ae7e5522b86e5d74d70f0c1a5b32eda3a0ae1635749060d0335a8856c778ea", upload-time = "2026-04-27T20:50:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a992bf8b3f2f4a8e0f2caf204ea1b1206466535eb485d4f61caf69a881e2fae7", upload-time = "2026-04-27T20:50:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:ce9aeead7950ae8eb48891568f9314a9a4130996b55e797c75e0c0d2846714ae", upload-time = "2026-04-27T20:52:26Z" },
 ]
 
 [[package]]
@@ -5513,10 +5515,10 @@ dependencies = [
     { name = "torch", version = "2.5.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (platform_machine != 'aarch64' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-linux_aarch64.whl", hash = "sha256:75f8a4d51a593c4bab6c9bf7d75bdd88691b00a53b07656678bc55a3a753dd73" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4878fefb96ef293d06c27210918adc83c399d9faaf34cda5a63e129f772328f1" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:a40d766345927639da322c693934e5f91b1ba2218846c7104b868dea2314ce8e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:344b339e15e6bbb59ee0700772616d0afefd209920c762b1604368d8c3458322" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-linux_aarch64.whl", hash = "sha256:75f8a4d51a593c4bab6c9bf7d75bdd88691b00a53b07656678bc55a3a753dd73", upload-time = "2024-10-29T23:02:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4878fefb96ef293d06c27210918adc83c399d9faaf34cda5a63e129f772328f1", upload-time = "2024-10-29T23:02:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:a40d766345927639da322c693934e5f91b1ba2218846c7104b868dea2314ce8e", upload-time = "2024-10-29T23:02:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:344b339e15e6bbb59ee0700772616d0afefd209920c762b1604368d8c3458322", upload-time = "2024-10-29T23:02:46Z" },
 ]
 
 [[package]]
@@ -5534,10 +5536,10 @@ dependencies = [
     { name = "torch", version = "2.5.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (sys_platform == 'linux' and extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:17bbc073920e429bf23a290472d51edc75e7b9809b81a93503d10d8edb6f3a6d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:58773dc7110425ff3ffa462ed32d5522deaed81179b24780136ebc493fb94feb" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:a4153bcc9f6219596c65761aa00588704e91e3db91d911c251e614f6140ed047" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:ebdeb19a49da0b5d11cc512a76b24a43971e17cfb9c1ec42564d0e300670d5fa" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:17bbc073920e429bf23a290472d51edc75e7b9809b81a93503d10d8edb6f3a6d", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:58773dc7110425ff3ffa462ed32d5522deaed81179b24780136ebc493fb94feb", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:a4153bcc9f6219596c65761aa00588704e91e3db91d911c251e614f6140ed047", upload-time = "2024-10-29T23:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.20.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:ebdeb19a49da0b5d11cc512a76b24a43971e17cfb9c1ec42564d0e300670d5fa", upload-time = "2024-10-29T23:02:42Z" },
 ]
 
 [[package]]
@@ -5561,10 +5563,10 @@ dependencies = [
     { name = "torch", version = "2.5.1+cu121", source = { registry = "https://download.pytorch.org/whl/cu121" }, marker = "(extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-cpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-fastattn' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra != 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra != 'extra-6-mussel-fastattn' and extra != 'extra-6-mussel-tensorflow-cpu' and extra != 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:304937b82c933d5155bd04d771f4b187273f67a76050bb4276b521f7e9b4c4e7" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:4cb1e44c1f7a4992f6d38a15633a1e694c093f1c52f3a036b1a719968031507a" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:237609a3551c2b68f32bcd3f3875dca93836010d83922ef2f3bd3a7540caee58" },
-    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:00143c941b30f2d5001b58f8caada826aaa4dce94b8ae4192730e5c34165fa8c" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:304937b82c933d5155bd04d771f4b187273f67a76050bb4276b521f7e9b4c4e7", upload-time = "2024-10-29T23:25:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp310-cp310-win_amd64.whl", hash = "sha256:4cb1e44c1f7a4992f6d38a15633a1e694c093f1c52f3a036b1a719968031507a", upload-time = "2024-10-29T23:25:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:237609a3551c2b68f32bcd3f3875dca93836010d83922ef2f3bd3a7540caee58", upload-time = "2024-10-29T23:25:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu121/torchvision-0.20.1%2Bcu121-cp311-cp311-win_amd64.whl", hash = "sha256:00143c941b30f2d5001b58f8caada826aaa4dce94b8ae4192730e5c34165fa8c", upload-time = "2024-10-29T23:25:42Z" },
 ]
 
 [[package]]
@@ -5591,12 +5593,12 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-6-mussel-fastattn' or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-tensorflow-gpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-cpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-cpu') or (extra == 'extra-6-mussel-tensorflow-gpu' and extra == 'extra-6-mussel-torch-gpu') or (extra == 'extra-6-mussel-torch-cpu' and extra == 'extra-6-mussel-torch-gpu')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f00219ac240be76ac7693dc0459d19d35b3a6bc778aeb461d70fa24a78602f14" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8af0ce71fb0c8773daa16443ac5b65f21a0b18a501bcf4fc7750c03a76bfc9ef" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:233a63229f773ad63ba9f6ea4713d905839aecd58291a169b1bcee7c29356029" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a197ed1684633b95a49f89cc860bbff763674d737f5ba5100be74caa98acd9f" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26bc03574a5e1d3b48348292d523e089db8e833fac2f56a49ebbfde571b90db2" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f00219ac240be76ac7693dc0459d19d35b3a6bc778aeb461d70fa24a78602f14", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8af0ce71fb0c8773daa16443ac5b65f21a0b18a501bcf4fc7750c03a76bfc9ef", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:233a63229f773ad63ba9f6ea4713d905839aecd58291a169b1bcee7c29356029", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a197ed1684633b95a49f89cc860bbff763674d737f5ba5100be74caa98acd9f", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26bc03574a5e1d3b48348292d523e089db8e833fac2f56a49ebbfde571b90db2", upload-time = "2026-03-23T15:36:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.26.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:67eb5dab7ae058e4a7ce44c682db8dbf28a9b381a658c7f778f08029d37574d4", upload-time = "2026-04-09T23:21:30Z" },
 ]
 
 [[package]]
@@ -5864,8 +5866,8 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl", hash = "sha256:bea6121a39992140ea7e3f61400c8964afc33a6f0b1e11abe654936de346e1d9", upload-time = "2026-04-27T21:22:38Z" },
+    { url = "https://download.pytorch.org/whl/cu126/xformers-0.0.35-py39-none-win_amd64.whl", hash = "sha256:68f82ada282e30f8f3d61a6ba13d2baea92231dfa2e68795d616600e9cef4f57", upload-time = "2026-04-27T21:22:39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Embedding precision selection

Adds `embedding_precision` parameter to `extract_features`, `aggregate_slide_features`, and `tessellate_extract_features` commands so users can save embeddings in float16 or bfloat16 instead of float32, reducing storage by up to 50%.

### Supported precisions
- `float32` (default, backward-compatible)
- `float16` — standard half-precision
- `bfloat16` — wider dynamic range than float16; preferred for ML workloads

### Semantics for slide-encoder pipelines

When generating slide embeddings (aggregation_method=model), **tile/patch embeddings are always kept at float32** internally because they are intermediate inputs to the slide encoder.  `embedding_precision` applies only to the **final saved output**:

| Pipeline | What gets cast |
|---|---|
| Tile encoder only | Tile features → output H5/PT |
| Slide encoder (model) | Slide features → output H5/PT; tile intermediates stay float32 |
| mean / max aggregation | Aggregated slide features → output H5/PT |

### bfloat16 HDF5 storage
bfloat16 is not a native HDF5 dtype. It is stored as opaque 2-byte data (`|V2`) and correctly round-trips via `ml_dtypes`. A new `_numpy_to_torch()` helper handles safe conversion from `|V2` arrays to `torch.bfloat16` tensors (replaces direct `torch.from_numpy()` calls).

### Changes
- `feature_extract.py`: `extract_patch_features`, `aggregate_slide_features`, `aggregate_slide_features_batch` — add `embedding_precision`; cast output before saving; non-model batch path (identity/mean/max) also gains the cast
- `save_features()` two-step path: tile extraction forced to `"float32"`; slide aggregation receives `embedding_precision`; removed now-obsolete warning
- `extract_features.py`: adds `embedding_precision` field to config
- `aggregate_slide_features.py`: adds `embedding_precision` field to config; passes it to `aggregate_slide_features()`
- `tessellate_extract_features.py`: adds `embedding_precision` field; Phase-3 slide aggregation and final tile PT exports cast accordingly; three `torch.from_numpy` calls replaced with `_numpy_to_torch` for bfloat16 safety

### Other changes in this PR
- `mpp_is_fallback` attribute stored in H5 coords to indicate when the default 0.5 µm/px MPP was used (slide metadata unavailable)
- `max_slide_patches` parameter caps patches per slide before slide encoding (addresses TITAN O(N²) attention OOM on large slides; reproducible subsampling per slide)

### Usage
```bash
# Save tile embeddings as float16 (tile encoder)
extract_features slide_path=slide.svs embedding_precision=float16

# Save slide embeddings as bfloat16 (slide encoder — tiles stay float32 internally)
tessellate_extract_features \
  slide_path=slide.svs \
  slide_model_type=TITAN_SLIDE \
  embedding_precision=bfloat16 \
  seg_config=biopsy

# Aggregate existing patch features and save as float16
aggregate_slide_features \
  patch_features_h5_path=patches.h5 \
  output_h5_path=slide.h5 \
  aggregation_method=mean \
  embedding_precision=float16
```

### Tests
- Unit tests for `_parse_feature_dtype` (all three precisions)
- HDF5 round-trip tests for bfloat16 via `H5DatasetProcessor` and `TileCoordProcessor`
- `test_aggregate_slide_features_precision`: verifies float16 and bfloat16 H5 output dtype
- `test_save_features_two_step_keeps_intermediate_float32`: verifies tile extraction receives `"float32"` while final slide output uses the requested precision
- `test_aggregate_slide_features_batch_precision`: batch function with float16
- Config field presence tests for `AggregateSlideFeaturesConfig` and `TessellateExtractFeaturesConfig`
- E2E tests: `test_e2e_embedding_precision_float16` and `test_e2e_embedding_precision_bfloat16`
