### PR TITLE
Fix conflict between numcodecs and zarr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "h5py",
   "matplotlib",
   "tiffslide",
+  "numcodecs<0.16",
   "opencv-python-headless",
   "hydra-core",
   "geopandas",


### PR DESCRIPTION
This is a one-line pyproject.toml change to force numcodecs<0.16, to avoid a conflict with zarr

Later versions of **numcodecs** remove a function '**cbuffer_sizes**' that **zarr v2.*** imports.  This caused the tesselate test to fail when run with a newly rebuilt torch-gpu environment.  This seemed like the simplest way to avoid that conflict, but we might also want to see if we could force **zarr 3.*** to be used.

For posterity's sake, here's how Gemini described the issue...

- Versions of zarr prior to 3.0.0 include a file (zarr/util.py) that explicitly imports cbuffer_sizes.
- API  Removal: The numcodecs developers removed several non-public functions in version 0.16.0, including init, destroy, cbuffer_sizes, and cbuffer_metainfo, because they were not intended for external use.
- Automatic Updates: If you recently ran pip install --upgrade or built a new environment without version pins, your system likely pulled the latest numcodecs (0.16.x), which is incompatible with older zarr versions.
- Upgrade Zarr: If your project allows it, upgrading to zarr 3.0.0 or higher should resolve the conflict, as the newer version of zarr no longer references the removed numcodecs functions.