### PR TITLE
fix: upcast float16/bfloat16 features to float32 in aggregate_sample_features

### DIFF
--- a/mussel/cli/aggregate_sample_features.py
+++ b/mussel/cli/aggregate_sample_features.py
@@ -139,7 +139,18 @@ def main(cfg: AggregateSampleFeaturesConfig):
         coords_list = []
         for i in indices:
             with h5py.File(patch_features_h5_paths[i], "r") as h5:
-                features_list.append(np.array(h5["features"]))
+                features_arr = np.array(h5["features"])
+                # HDF5 stores bfloat16 as |V2 opaque void (via ml_dtypes). Cast both
+                # bfloat16 and float16 to float32 so downstream consumers work correctly.
+                if features_arr.dtype.kind == "V" and features_arr.dtype.itemsize == 2:
+                    import ml_dtypes  # noqa: PLC0415
+
+                    features_arr = features_arr.view(ml_dtypes.bfloat16).astype(
+                        np.float32
+                    )
+                elif features_arr.dtype == np.float16:
+                    features_arr = features_arr.astype(np.float32)
+                features_list.append(features_arr)
                 coords_list.append(h5["coords"][:])
 
         result = aggregate_sample_features(

--- a/mussel/cli/aggregate_sample_features.py
+++ b/mussel/cli/aggregate_sample_features.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import h5py
 import hydra
+import ml_dtypes
 import numpy as np
 import torch
 from hydra.conf import HelpConf, HydraConf
@@ -143,8 +144,6 @@ def main(cfg: AggregateSampleFeaturesConfig):
                 # HDF5 stores bfloat16 as |V2 opaque void (via ml_dtypes). Cast both
                 # bfloat16 and float16 to float32 so downstream consumers work correctly.
                 if features_arr.dtype.kind == "V" and features_arr.dtype.itemsize == 2:
-                    import ml_dtypes  # noqa: PLC0415
-
                     features_arr = features_arr.view(ml_dtypes.bfloat16).astype(
                         np.float32
                     )

--- a/mussel/utils/file.py
+++ b/mussel/utils/file.py
@@ -342,7 +342,21 @@ def load_features_from_h5(h5_path: str, pt_path: Optional[str] = None):
         if pt_path and os.path.exists(pt_path):
             features = torch.load(pt_path, weights_only=True)
         else:
-            features = torch.from_numpy(np.array(h5["features"]))
+            features_arr = np.array(h5["features"])
+            # HDF5 stores bfloat16 as |V2 opaque void (via ml_dtypes). Cast both
+            # bfloat16 and float16 to float32 so downstream consumers work correctly.
+            if features_arr.dtype.kind == "V" and features_arr.dtype.itemsize == 2:
+                try:
+                    import ml_dtypes
+                except ImportError:
+                    raise ImportError(
+                        "ml_dtypes is required to load bfloat16 features. "
+                        "Install it with: pip install ml-dtypes"
+                    )
+                features_arr = features_arr.view(ml_dtypes.bfloat16).astype(np.float32)
+            elif features_arr.dtype == np.float16:
+                features_arr = features_arr.astype(np.float32)
+            features = torch.from_numpy(features_arr)
         coords = h5["coords"][:]
     return features, coords
 

--- a/mussel/utils/file.py
+++ b/mussel/utils/file.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import h5py
+import ml_dtypes
 import numpy as np
 import torch
 
@@ -346,13 +347,6 @@ def load_features_from_h5(h5_path: str, pt_path: Optional[str] = None):
             # HDF5 stores bfloat16 as |V2 opaque void (via ml_dtypes). Cast both
             # bfloat16 and float16 to float32 so downstream consumers work correctly.
             if features_arr.dtype.kind == "V" and features_arr.dtype.itemsize == 2:
-                try:
-                    import ml_dtypes
-                except ImportError:
-                    raise ImportError(
-                        "ml_dtypes is required to load bfloat16 features. "
-                        "Install it with: pip install ml-dtypes"
-                    )
                 features_arr = features_arr.view(ml_dtypes.bfloat16).astype(np.float32)
             elif features_arr.dtype == np.float16:
                 features_arr = features_arr.astype(np.float32)

--- a/tests/mussel/cli/test_aggregate_sample_features.py
+++ b/tests/mussel/cli/test_aggregate_sample_features.py
@@ -1,4 +1,5 @@
 import h5py
+import ml_dtypes
 import numpy as np
 import pytest
 import torch
@@ -329,12 +330,12 @@ def test_cli_mismatched_lengths_raises(tmp_path):
 def test_float16_features_upcast_to_float32(tmp_path):
     """float16 features stored in h5 are upcast to float32 in the output H5."""
     n_tiles, dim = 6, 8
-    rng = np.random.default_rng(0)
-    orig_f32 = rng.random((n_tiles, dim)).astype(np.float32)
-    expected = orig_f32.astype(np.float16).astype(np.float32)
-
     h5_path = tmp_path / "slide.h5"
     _write_fake_h5(h5_path, n_tiles=n_tiles, dim=dim, seed=0, feature_dtype=np.float16)
+
+    # Read back the exact values written so expected matches what was stored.
+    with h5py.File(h5_path) as f:
+        expected = f["features"][:].astype(np.float32)
 
     cfg = AggregateSampleFeaturesConfig(
         patch_features_h5_paths=[str(h5_path)],
@@ -350,28 +351,22 @@ def test_float16_features_upcast_to_float32(tmp_path):
     assert (
         out_features.dtype == np.float32
     ), f"Expected float32 output, got {out_features.dtype}"
-    np.testing.assert_allclose(
-        out_features,
-        expected,
-        rtol=1e-3,
-        err_msg="Float16→float32 values differ more than expected",
-    )
+    np.testing.assert_array_equal(out_features, expected)
 
 
 def test_bfloat16_features_upcast_to_float32(tmp_path):
     """bfloat16 features (stored as |V2 opaque void in h5) are upcast to float32."""
-    import ml_dtypes
-
     n_tiles, dim = 6, 8
-    rng = np.random.default_rng(0)
-    orig_f32 = rng.random((n_tiles, dim)).astype(np.float32)
-    expected = orig_f32.astype(ml_dtypes.bfloat16).astype(np.float32)
-
     h5_path = tmp_path / "slide.h5"
     _write_fake_h5(
         h5_path, n_tiles=n_tiles, dim=dim, seed=0, feature_dtype=ml_dtypes.bfloat16
     )
 
+    # Read back the exact opaque bytes written and reinterpret as float32.
+    with h5py.File(h5_path) as f:
+        raw = np.array(f["features"])
+    expected = raw.view(ml_dtypes.bfloat16).astype(np.float32)
+
     cfg = AggregateSampleFeaturesConfig(
         patch_features_h5_paths=[str(h5_path)],
         sample_ids=["s1"],
@@ -386,9 +381,4 @@ def test_bfloat16_features_upcast_to_float32(tmp_path):
     assert (
         out_features.dtype == np.float32
     ), f"Expected float32 output, got {out_features.dtype}"
-    np.testing.assert_allclose(
-        out_features,
-        expected,
-        rtol=1e-2,
-        err_msg="Bfloat16→float32 values differ more than expected",
-    )
+    np.testing.assert_array_equal(out_features, expected)

--- a/tests/mussel/cli/test_aggregate_sample_features.py
+++ b/tests/mussel/cli/test_aggregate_sample_features.py
@@ -13,10 +13,10 @@ def _make_data(n_tiles, dim=4):
     return features, coords
 
 
-def _write_fake_h5(path, n_tiles, dim=4, seed=0):
+def _write_fake_h5(path, n_tiles, dim=4, seed=0, feature_dtype=np.float32):
     """Write a synthetic feature H5 with 'features' and 'coords' datasets."""
     rng = np.random.default_rng(seed)
-    features = rng.random((n_tiles, dim)).astype(np.float32)
+    features = rng.random((n_tiles, dim)).astype(feature_dtype)
     coords = rng.integers(0, 1000, (n_tiles, 2))
     with h5py.File(path, "w") as f:
         f.create_dataset("features", data=features)
@@ -120,8 +120,9 @@ def test_subsample_tiles_invalid_strategy():
 # =============================================================================
 
 
-from mussel.utils.feature_extract import \
-    aggregate_sample_features as _aggregate_sample_features
+from mussel.utils.feature_extract import (
+    aggregate_sample_features as _aggregate_sample_features,
+)
 
 
 def test_aggregate_sample_features_invalid_shapes():
@@ -216,7 +217,10 @@ def test_aggregate_sample_features_save_pt_false(tmp_path):
 def test_aggregate_sample_features_two_samples(tmp_path):
     """Three slides, two samples — two entries in result."""
     rng = np.random.default_rng(0)
-    slides = [(rng.random((10, 4)).astype(np.float32), rng.integers(0, 1000, (10, 2))) for _ in range(3)]
+    slides = [
+        (rng.random((10, 4)).astype(np.float32), rng.integers(0, 1000, (10, 2)))
+        for _ in range(3)
+    ]
     features_list = [f for f, _ in slides]
     coords_list = [c for _, c in slides]
 
@@ -315,3 +319,76 @@ def test_cli_mismatched_lengths_raises(tmp_path):
     )
     with pytest.raises((ValueError, Exception)):
         mussel.cli.aggregate_sample_features.main(OmegaConf.structured(cfg))
+
+
+# =============================================================================
+# Precision upcast tests
+# =============================================================================
+
+
+def test_float16_features_upcast_to_float32(tmp_path):
+    """float16 features stored in h5 are upcast to float32 in the output H5."""
+    n_tiles, dim = 6, 8
+    rng = np.random.default_rng(0)
+    orig_f32 = rng.random((n_tiles, dim)).astype(np.float32)
+    expected = orig_f32.astype(np.float16).astype(np.float32)
+
+    h5_path = tmp_path / "slide.h5"
+    _write_fake_h5(h5_path, n_tiles=n_tiles, dim=dim, seed=0, feature_dtype=np.float16)
+
+    cfg = AggregateSampleFeaturesConfig(
+        patch_features_h5_paths=[str(h5_path)],
+        sample_ids=["s1"],
+        output_dir=str(tmp_path / "out"),
+        save_pt=False,
+    )
+    mussel.cli.aggregate_sample_features.main(OmegaConf.structured(cfg))
+
+    with h5py.File(tmp_path / "out" / "s1.features.h5") as f:
+        out_features = f["features"][:]
+
+    assert (
+        out_features.dtype == np.float32
+    ), f"Expected float32 output, got {out_features.dtype}"
+    np.testing.assert_allclose(
+        out_features,
+        expected,
+        rtol=1e-3,
+        err_msg="Float16→float32 values differ more than expected",
+    )
+
+
+def test_bfloat16_features_upcast_to_float32(tmp_path):
+    """bfloat16 features (stored as |V2 opaque void in h5) are upcast to float32."""
+    import ml_dtypes
+
+    n_tiles, dim = 6, 8
+    rng = np.random.default_rng(0)
+    orig_f32 = rng.random((n_tiles, dim)).astype(np.float32)
+    expected = orig_f32.astype(ml_dtypes.bfloat16).astype(np.float32)
+
+    h5_path = tmp_path / "slide.h5"
+    _write_fake_h5(
+        h5_path, n_tiles=n_tiles, dim=dim, seed=0, feature_dtype=ml_dtypes.bfloat16
+    )
+
+    cfg = AggregateSampleFeaturesConfig(
+        patch_features_h5_paths=[str(h5_path)],
+        sample_ids=["s1"],
+        output_dir=str(tmp_path / "out"),
+        save_pt=False,
+    )
+    mussel.cli.aggregate_sample_features.main(OmegaConf.structured(cfg))
+
+    with h5py.File(tmp_path / "out" / "s1.features.h5") as f:
+        out_features = f["features"][:]
+
+    assert (
+        out_features.dtype == np.float32
+    ), f"Expected float32 output, got {out_features.dtype}"
+    np.testing.assert_allclose(
+        out_features,
+        expected,
+        rtol=1e-2,
+        err_msg="Bfloat16→float32 values differ more than expected",
+    )

--- a/tests/mussel/utils/test_file.py
+++ b/tests/mussel/utils/test_file.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pytest
+import torch
 
-from mussel.utils.file import load_pkl, save_hdf5, save_pkl
+from mussel.utils.file import load_features_from_h5, load_pkl, save_hdf5, save_pkl
 
 
 def test_save_and_load_pkl(tmp_path):
@@ -90,3 +92,51 @@ def test_save_hdf5_with_attr_h5_path(tmp_path):
     with h5py.File(target_file, "r") as f:
         assert f["data"].attrs["source"] == "test"
         assert f["data"].attrs["version"] == 1
+
+
+# =============================================================================
+# load_features_from_h5 dtype upcast tests
+# =============================================================================
+
+
+def _write_features_h5(path, features: np.ndarray):
+    coords = np.zeros((len(features), 2), dtype=np.int64)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("features", data=features)
+        f.create_dataset("coords", data=coords)
+
+
+def test_load_features_from_h5_float32(tmp_path):
+    """float32 features are loaded as-is."""
+    feats = np.random.default_rng(0).random((4, 8)).astype(np.float32)
+    h5_path = tmp_path / "slide.h5"
+    _write_features_h5(h5_path, feats)
+
+    result, _ = load_features_from_h5(str(h5_path))
+    assert result.dtype == torch.float32
+    np.testing.assert_allclose(result.numpy(), feats)
+
+
+def test_load_features_from_h5_float16_upcast(tmp_path):
+    """float16 features are upcast to float32."""
+    feats = np.random.default_rng(0).random((4, 8)).astype(np.float16)
+    h5_path = tmp_path / "slide.h5"
+    _write_features_h5(h5_path, feats)
+
+    result, _ = load_features_from_h5(str(h5_path))
+    assert result.dtype == torch.float32
+    np.testing.assert_allclose(result.numpy(), feats.astype(np.float32), rtol=1e-3)
+
+
+def test_load_features_from_h5_bfloat16_upcast(tmp_path):
+    """bfloat16 features (stored as |V2 opaque void) are upcast to float32."""
+    ml_dtypes = pytest.importorskip("ml_dtypes")
+    feats = np.random.default_rng(0).random((4, 8)).astype(ml_dtypes.bfloat16)
+    h5_path = tmp_path / "slide.h5"
+    _write_features_h5(h5_path, feats)
+
+    result, _ = load_features_from_h5(str(h5_path))
+    assert result.dtype == torch.float32
+    np.testing.assert_allclose(
+        result.numpy(), feats.astype(np.float32), rtol=1e-2
+    )


### PR DESCRIPTION
## Problem

Follow-up to #122. `aggregate_sample_features.py` has the same raw h5 read pattern (line 142):

```python
features_list.append(np.array(h5["features"]))
```

- **bfloat16** is stored as `|V2` (2-byte opaque void) via `ml_dtypes` — downstream consumers (sklearn, parquet) cannot handle this dtype.
- **float16** causes dtype errors in sklearn estimators that require `float32`.

## Fix

Cast bfloat16 and float16 features to `float32` immediately after reading from h5:

```python
features_arr = np.array(h5["features"])
if features_arr.dtype.kind == "V" and features_arr.dtype.itemsize == 2:
    import ml_dtypes
    features_arr = features_arr.view(ml_dtypes.bfloat16).astype(np.float32)
elif features_arr.dtype == np.float16:
    features_arr = features_arr.astype(np.float32)
features_list.append(features_arr)
```

## Tests

Two new round-trip tests added to `test_aggregate_sample_features.py`:

- `test_float16_features_upcast_to_float32` — verifies output H5 dtype is `float32` and values match the float16 round-trip
- `test_bfloat16_features_upcast_to_float32` — same for bfloat16 (`|V2` opaque void)

All 17 tests pass.