### PR TITLE
fix: resolve two artifact removal issues in tessellate_extract_features

### DIFF
--- a/mussel/cli/filter_tessellate.py
+++ b/mussel/cli/filter_tessellate.py
@@ -16,7 +16,8 @@ from omegaconf import MISSING, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig)
+                                   TcgaSegConfig, VisConfig,
+                                   _build_artifact_remover)
 from mussel.cli.tessellate_extract_features_common import _build_grid_polygons
 from mussel.models import ModelType, get_default_patch_size
 from mussel.utils import (filter_features, load_classifier,
@@ -166,11 +167,17 @@ def _main(cfg: FilterTessellateConfig, temp_dir, base_path):
     else:
         tessellate_h5_path = os.path.join(temp_dir, "tessellate.h5")
 
+    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    # Strip config-only keys that are not segment_tissue() parameters.
+    seg_cfg.pop("artifact_exclude_classes", None)
+
     if values := segment_tissue(
         slide_path=cfg.slide_path,
         slide_id=cfg.slide_id,
         output_h5_path=tessellate_h5_path,
-        **OmegaConf.to_container(cfg.seg_config),
+        artifact_remover_fn=artifact_remover_fn,
+        **seg_cfg,
     ):
         polygon, grid, coords, _ = values
     else:

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -106,6 +106,15 @@ class SegConfig:
     remove_penmarks: bool = (
         False  # If True, apply pen mark removal to the tissue mask before patching.
     )
+    artifact_exclude_classes: Optional[List[int]] = field(
+        default=None
+    )
+    # Optional list of GrandQC class indices to exclude (overrides remove_artifacts /
+    # remove_penmarks preset logic when set).  Use the CLASS_* constants from
+    # mussel.utils.artifact_removal, e.g. [4, 7] for pen marks + background only.
+    # Common presets: EXCLUDE_PENMARKS_ONLY=[4,7], EXCLUDE_FOLDS_AND_PENMARKS=[4,5,6,7],
+    # EXCLUDE_ALL_ARTIFACTS=[2,3,4,5,6,7].  When None, the preset is derived from the
+    # remove_artifacts / remove_penmarks flags.
     seg_model: str = (
         "classic"  # "classic" (HSV + fixed threshold), "otsu" (HSV + Otsu), or "neural" (DeepLabV3).
     )
@@ -301,11 +310,14 @@ def main(
     cfg: TessellateConfig,
 ):
     """Tile a whole slide image and perform tissue segmentation."""
+    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    # Strip config-only keys that are not segment_tissue() parameters.
+    seg_cfg.pop("artifact_exclude_classes", None)
     if values := segment_tissue(
         slide_path=cfg.slide_path,
         slide_id=cfg.slide_id,
         output_h5_path=cfg.output_h5_path,
-        **OmegaConf.to_container(cfg.seg_config),
+        **seg_cfg,
     ):
         polygon, grid, coords, _ = values
     else:

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -16,6 +16,11 @@ from omegaconf import MISSING, OmegaConf
 
 logger = logging.getLogger(__name__)
 
+from mussel.utils.artifact_removal import (
+    EXCLUDE_ALL_ARTIFACTS,
+    EXCLUDE_PENMARKS_ONLY,
+    GrandQCArtifactRemover,
+)
 from mussel.utils.segment import (draw_slide_mask, save_patches_png,
                                   segment_tissue)
 
@@ -305,18 +310,62 @@ cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
 cs.store(name="tessellate_config", node=TessellateConfig)
 
 
+def _build_artifact_remover(
+    seg_cfg: dict,
+) -> "Optional[GrandQCArtifactRemover]":
+    """Instantiate a :class:`~mussel.utils.artifact_removal.GrandQCArtifactRemover`
+    from a plain ``seg_cfg`` dict (as returned by ``OmegaConf.to_container``).
+
+    Returns ``None`` when artifact removal is not requested.  The returned
+    instance is safe to share across multiple slides.
+
+    Exclusion set resolution order:
+
+    1. ``artifact_exclude_classes`` list — full per-run control.
+    2. Flags ``remove_artifacts`` / ``remove_penmarks``:
+
+       * ``remove_artifacts=True``             → :data:`~mussel.utils.artifact_removal.EXCLUDE_ALL_ARTIFACTS`
+       * ``remove_penmarks=True`` only         → :data:`~mussel.utils.artifact_removal.EXCLUDE_PENMARKS_ONLY`
+    """
+    if not (seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks")):
+        return None
+
+    explicit = seg_cfg.get("artifact_exclude_classes")
+    if explicit:
+        exclude_classes = frozenset(int(c) for c in explicit)
+        mode = f"custom {sorted(exclude_classes)}"
+    elif bool(seg_cfg.get("remove_artifacts")):
+        exclude_classes = EXCLUDE_ALL_ARTIFACTS
+        mode = "EXCLUDE_ALL_ARTIFACTS (aggressive)"
+    else:
+        exclude_classes = EXCLUDE_PENMARKS_ONLY
+        mode = "EXCLUDE_PENMARKS_ONLY (conservative)"
+
+    remover = GrandQCArtifactRemover(exclude_classes=exclude_classes)
+    logger.info(
+        "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s "
+        "exclude_classes=%s",
+        seg_cfg.get("remove_artifacts"),
+        seg_cfg.get("remove_penmarks"),
+        mode,
+    )
+    return remover
+
+
 @hydra.main(version_base=None, config_path=".", config_name="tessellate_config")
 def main(
     cfg: TessellateConfig,
 ):
     """Tile a whole slide image and perform tissue segmentation."""
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    artifact_remover_fn = _build_artifact_remover(seg_cfg)
     # Strip config-only keys that are not segment_tissue() parameters.
     seg_cfg.pop("artifact_exclude_classes", None)
     if values := segment_tissue(
         slide_path=cfg.slide_path,
         slide_id=cfg.slide_id,
         output_h5_path=cfg.output_h5_path,
+        artifact_remover_fn=artifact_remover_fn,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -37,7 +37,11 @@ from mussel.utils import (aggregate_slide_features_batch,
                           resolve_aggregation_method, resolve_patch_encoder,
                           resolve_remote_paths, safe_path_join,
                           save_torch_tensor)
-from mussel.utils.artifact_removal import GrandQCArtifactRemover
+from mussel.utils.artifact_removal import (
+    EXCLUDE_ALL_ARTIFACTS,
+    EXCLUDE_PENMARKS_ONLY,
+    GrandQCArtifactRemover,
+)
 from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
 
@@ -417,26 +421,39 @@ def _build_artifact_remover(
 ) -> Optional[GrandQCArtifactRemover]:
     """Instantiate a :class:`GrandQCArtifactRemover` from ``cfg.seg_config``.
 
-    Returns ``None`` when artifact removal is not requested (both
-    ``remove_artifacts`` and ``remove_penmarks`` are falsy).  The returned
-    instance can be shared across multiple slides in a batch to avoid
-    reloading model weights.
+    Returns ``None`` when artifact removal is not requested.  The returned
+    instance is shared across all slides in a batch to avoid reloading weights.
+
+    Exclusion set resolution order:
+        1. ``artifact_exclude_classes`` list in seg_config — full per-run control.
+        2. Flags ``remove_artifacts`` / ``remove_penmarks``:
+              both True or ``remove_artifacts`` only → :data:`EXCLUDE_ALL_ARTIFACTS`
+              ``remove_penmarks`` only              → :data:`EXCLUDE_PENMARKS_ONLY`
     """
     from omegaconf import OmegaConf
 
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
     if not (seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks")):
         return None
-    remover = GrandQCArtifactRemover(
-        remove_penmarks_only=(
-            bool(seg_cfg.get("remove_penmarks"))
-            and not bool(seg_cfg.get("remove_artifacts"))
-        )
-    )
+
+    explicit = seg_cfg.get("artifact_exclude_classes")
+    if explicit:
+        exclude_classes = frozenset(int(c) for c in explicit)
+        mode = f"custom {sorted(exclude_classes)}"
+    elif bool(seg_cfg.get("remove_artifacts")):
+        exclude_classes = EXCLUDE_ALL_ARTIFACTS
+        mode = "EXCLUDE_ALL_ARTIFACTS (aggressive)"
+    else:
+        exclude_classes = EXCLUDE_PENMARKS_ONLY
+        mode = "EXCLUDE_PENMARKS_ONLY (conservative)"
+
+    remover = GrandQCArtifactRemover(exclude_classes=exclude_classes)
     logger.info(
-        "Artifact removal enabled (shared instance): remove_artifacts=%s remove_penmarks=%s",
+        "Artifact removal enabled (shared instance): remove_artifacts=%s "
+        "remove_penmarks=%s exclude_classes=%s",
         seg_cfg.get("remove_artifacts"),
         seg_cfg.get("remove_penmarks"),
+        mode,
     )
     return remover
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -21,7 +21,8 @@ from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig)
+                                   TcgaSegConfig, VisConfig,
+                                   _build_artifact_remover)
 from mussel.cli.tessellate_extract_features_common import (
     create_visualizations, process_slide_tessellation_and_filtering,
     process_slide_tessellation_only)
@@ -416,48 +417,6 @@ def main(
             _main_single(cfg)
 
 
-def _build_artifact_remover(
-    cfg: TessellateExtractFeaturesConfig,
-) -> Optional[GrandQCArtifactRemover]:
-    """Instantiate a :class:`GrandQCArtifactRemover` from ``cfg.seg_config``.
-
-    Returns ``None`` when artifact removal is not requested.  The returned
-    instance is shared across all slides in a batch to avoid reloading weights.
-
-    Exclusion set resolution order:
-        1. ``artifact_exclude_classes`` list in seg_config — full per-run control.
-        2. Flags ``remove_artifacts`` / ``remove_penmarks``:
-              both True or ``remove_artifacts`` only → :data:`EXCLUDE_ALL_ARTIFACTS`
-              ``remove_penmarks`` only              → :data:`EXCLUDE_PENMARKS_ONLY`
-    """
-    from omegaconf import OmegaConf
-
-    seg_cfg = OmegaConf.to_container(cfg.seg_config)
-    if not (seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks")):
-        return None
-
-    explicit = seg_cfg.get("artifact_exclude_classes")
-    if explicit:
-        exclude_classes = frozenset(int(c) for c in explicit)
-        mode = f"custom {sorted(exclude_classes)}"
-    elif bool(seg_cfg.get("remove_artifacts")):
-        exclude_classes = EXCLUDE_ALL_ARTIFACTS
-        mode = "EXCLUDE_ALL_ARTIFACTS (aggressive)"
-    else:
-        exclude_classes = EXCLUDE_PENMARKS_ONLY
-        mode = "EXCLUDE_PENMARKS_ONLY (conservative)"
-
-    remover = GrandQCArtifactRemover(exclude_classes=exclude_classes)
-    logger.info(
-        "Artifact removal enabled (shared instance): remove_artifacts=%s "
-        "remove_penmarks=%s exclude_classes=%s",
-        seg_cfg.get("remove_artifacts"),
-        seg_cfg.get("remove_penmarks"),
-        mode,
-    )
-    return remover
-
-
 @resolve_remote_paths("model_dir", "classifier_pkl", auto_detect=False)
 def _main_single(cfg: TessellateExtractFeaturesConfig):
     """Process a single slide."""
@@ -589,7 +548,7 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
     )
     skip_second_extraction = use_filtering and models_are_same
 
-    artifact_remover_fn = _build_artifact_remover(cfg)
+    artifact_remover_fn = _build_artifact_remover(OmegaConf.to_container(cfg.seg_config))
 
     # Process the slide using shared logic
     result = process_slide_tessellation_and_filtering(
@@ -770,7 +729,7 @@ def _main_batch(
 
     # Instantiate artifact remover once per batch so model weights are loaded
     # only once rather than once per slide.
-    artifact_remover_fn = _build_artifact_remover(cfg)
+    artifact_remover_fn = _build_artifact_remover(OmegaConf.to_container(cfg.seg_config))
 
     slide_results = []
     for i, (slide_path, slide_id) in enumerate(zip(cfg.slide_paths, slide_ids)):

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -37,6 +37,7 @@ from mussel.utils import (aggregate_slide_features_batch,
                           resolve_aggregation_method, resolve_patch_encoder,
                           resolve_remote_paths, safe_path_join,
                           save_torch_tensor)
+from mussel.utils.artifact_removal import GrandQCArtifactRemover
 from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
 
@@ -411,6 +412,35 @@ def main(
             _main_single(cfg)
 
 
+def _build_artifact_remover(
+    cfg: TessellateExtractFeaturesConfig,
+) -> Optional[GrandQCArtifactRemover]:
+    """Instantiate a :class:`GrandQCArtifactRemover` from ``cfg.seg_config``.
+
+    Returns ``None`` when artifact removal is not requested (both
+    ``remove_artifacts`` and ``remove_penmarks`` are falsy).  The returned
+    instance can be shared across multiple slides in a batch to avoid
+    reloading model weights.
+    """
+    from omegaconf import OmegaConf
+
+    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    if not (seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks")):
+        return None
+    remover = GrandQCArtifactRemover(
+        remove_penmarks_only=(
+            bool(seg_cfg.get("remove_penmarks"))
+            and not bool(seg_cfg.get("remove_artifacts"))
+        )
+    )
+    logger.info(
+        "Artifact removal enabled (shared instance): remove_artifacts=%s remove_penmarks=%s",
+        seg_cfg.get("remove_artifacts"),
+        seg_cfg.get("remove_penmarks"),
+    )
+    return remover
+
+
 @resolve_remote_paths("model_dir", "classifier_pkl", auto_detect=False)
 def _main_single(cfg: TessellateExtractFeaturesConfig):
     """Process a single slide."""
@@ -542,6 +572,8 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
     )
     skip_second_extraction = use_filtering and models_are_same
 
+    artifact_remover_fn = _build_artifact_remover(cfg)
+
     # Process the slide using shared logic
     result = process_slide_tessellation_and_filtering(
         slide_path=cfg.slide_path,
@@ -560,6 +592,7 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
         output_mask_path=cfg.output_mask_path,
         two_step_mode=False,  # Single-slide mode doesn't use two-step
         slide_model_path=slide_model_path,
+        artifact_remover_fn=artifact_remover_fn,
     )
 
     if result is None:
@@ -718,6 +751,10 @@ def _main_batch(
     # Phase 1: Tessellate all slides and perform filtering if needed
     logger.info(f"\n=== Phase 1: Tessellating {len(cfg.slide_paths)} slides ===")
 
+    # Instantiate artifact remover once per batch so model weights are loaded
+    # only once rather than once per slide.
+    artifact_remover_fn = _build_artifact_remover(cfg)
+
     slide_results = []
     for i, (slide_path, slide_id) in enumerate(zip(cfg.slide_paths, slide_ids)):
         logger.info(f"\nTessellating slide {i + 1}/{len(cfg.slide_paths)}: {slide_id}")
@@ -742,6 +779,7 @@ def _main_batch(
                 prefilter_model_path=prefilter_model_path,
                 skip_second_extraction=skip_second_extraction,
                 output_mask_path=output_mask_path,
+                artifact_remover_fn=artifact_remover_fn,
             )
 
             if result is None:

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -31,6 +31,7 @@ def _tessellate_and_filter(
     prefilter_model_path: Optional[str],
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
+    artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
 ) -> Optional[dict]:
     """Tessellate a slide and optionally extract/filter features for tile selection.
 
@@ -49,6 +50,11 @@ def _tessellate_and_filter(
         skip_second_extraction: Whether the pre-filter model is also the final model
             (caller can use pre-filter features directly as final output).
         output_mask_path: Optional path to save a tissue mask visualisation.
+        artifact_remover_fn: Pre-instantiated :class:`GrandQCArtifactRemover` to
+            use for artifact removal.  When provided this instance is reused across
+            slides (weights are loaded only once).  When ``None`` a new instance is
+            created from ``cfg.seg_config`` flags, which incurs a model-weight
+            download on first use for every slide.
 
     Returns:
         ``None`` on tessellation failure; otherwise a dict with:
@@ -75,19 +81,19 @@ def _tessellate_and_filter(
 
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
 
-    artifact_remover_fn = None
-    if seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks"):
-        artifact_remover_fn = GrandQCArtifactRemover(
-            remove_penmarks_only=(
-                bool(seg_cfg.get("remove_penmarks"))
-                and not bool(seg_cfg.get("remove_artifacts"))
+    if artifact_remover_fn is None:
+        if seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks"):
+            artifact_remover_fn = GrandQCArtifactRemover(
+                remove_penmarks_only=(
+                    bool(seg_cfg.get("remove_penmarks"))
+                    and not bool(seg_cfg.get("remove_artifacts"))
+                )
             )
-        )
-        logger.info(
-            "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s",
-            seg_cfg.get("remove_artifacts"),
-            seg_cfg.get("remove_penmarks"),
-        )
+            logger.info(
+                "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s",
+                seg_cfg.get("remove_artifacts"),
+                seg_cfg.get("remove_penmarks"),
+            )
 
     if values := segment_tissue(
         slide_path=slide_path,
@@ -213,6 +219,7 @@ def process_slide_tessellation_and_filtering(
     output_mask_path: Optional[str] = None,
     two_step_mode: bool = False,
     slide_model_path: Optional[str] = None,
+    artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
 ) -> Optional[dict]:
     """Process a single slide through tessellation, optional filtering, and feature extraction.
 
@@ -233,6 +240,8 @@ def process_slide_tessellation_and_filtering(
         output_mask_path: Optional path to save mask visualization.
         two_step_mode: Whether using two-step aggregation (for batch processing).
         slide_model_path: Path to slide encoder model weights.
+        artifact_remover_fn: Pre-instantiated artifact remover to reuse across slides.
+            See :func:`_tessellate_and_filter` for details.
 
     Returns:
         ``None`` if processing failed (tessellation error); otherwise a dict with
@@ -250,6 +259,7 @@ def process_slide_tessellation_and_filtering(
         prefilter_model_path=prefilter_model_path,
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
+        artifact_remover_fn=artifact_remover_fn,
     )
     if result is None:
         return None
@@ -347,6 +357,7 @@ def process_slide_tessellation_only(
     prefilter_model_path: Optional[str],
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
+    artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
 ) -> Optional[dict]:
     """Process a slide through tessellation and optional filtering (no feature extraction).
 
@@ -363,6 +374,8 @@ def process_slide_tessellation_only(
         prefilter_model_path: Path to pre-filter model weights.
         skip_second_extraction: Whether the pre-filter model is also the final model.
         output_mask_path: Optional path to save mask visualization.
+        artifact_remover_fn: Pre-instantiated artifact remover to reuse across slides.
+            See :func:`_tessellate_and_filter` for details.
 
     Returns:
         Dict with paths and coordinates for batch feature extraction, or ``None`` on failure.
@@ -378,6 +391,7 @@ def process_slide_tessellation_only(
         prefilter_model_path=prefilter_model_path,
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
+        artifact_remover_fn=artifact_remover_fn,
     )
     if result is None:
         return None

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 from mussel.utils import (filter_features, is_remote_path, load_classifier,
                           load_features_from_h5, safe_path_join, save_features,
                           save_hdf5, save_torch_tensor)
+from mussel.utils.artifact_removal import GrandQCArtifactRemover
 from mussel.utils.segment import (draw_slide_mask, save_patches_png,
                                   segment_tissue)
 
@@ -72,11 +73,28 @@ def _tessellate_and_filter(
             temp_dir, f"{Path(slide_path).stem}.tessellate.h5"
         )
 
+    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+
+    artifact_remover_fn = None
+    if seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks"):
+        artifact_remover_fn = GrandQCArtifactRemover(
+            remove_penmarks_only=(
+                bool(seg_cfg.get("remove_penmarks"))
+                and not bool(seg_cfg.get("remove_artifacts"))
+            )
+        )
+        logger.info(
+            "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s",
+            seg_cfg.get("remove_artifacts"),
+            seg_cfg.get("remove_penmarks"),
+        )
+
     if values := segment_tissue(
         slide_path=slide_path,
         slide_id=slide_id,
         output_h5_path=tessellate_h5_path,
-        **OmegaConf.to_container(cfg.seg_config),
+        artifact_remover_fn=artifact_remover_fn,
+        **seg_cfg,
     ):
         polygon, grid, coords, _ = values
     else:

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -12,14 +12,11 @@ from shapely.geometry import Polygon
 
 logger = logging.getLogger(__name__)
 
+from mussel.cli.tessellate import _build_artifact_remover
 from mussel.utils import (filter_features, is_remote_path, load_classifier,
                           load_features_from_h5, safe_path_join, save_features,
                           save_hdf5, save_torch_tensor)
-from mussel.utils.artifact_removal import (
-    EXCLUDE_ALL_ARTIFACTS,
-    EXCLUDE_PENMARKS_ONLY,
-    GrandQCArtifactRemover,
-)
+from mussel.utils.artifact_removal import GrandQCArtifactRemover
 from mussel.utils.segment import (draw_slide_mask, save_patches_png,
                                   segment_tissue)
 
@@ -86,22 +83,7 @@ def _tessellate_and_filter(
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
 
     if artifact_remover_fn is None:
-        if seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks"):
-            explicit = seg_cfg.get("artifact_exclude_classes")
-            if explicit:
-                exclude_classes = frozenset(int(c) for c in explicit)
-            elif bool(seg_cfg.get("remove_artifacts")):
-                exclude_classes = EXCLUDE_ALL_ARTIFACTS
-            else:
-                exclude_classes = EXCLUDE_PENMARKS_ONLY
-            artifact_remover_fn = GrandQCArtifactRemover(exclude_classes=exclude_classes)
-            logger.info(
-                "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s "
-                "exclude_classes=%s",
-                seg_cfg.get("remove_artifacts"),
-                seg_cfg.get("remove_penmarks"),
-                sorted(exclude_classes),
-            )
+        artifact_remover_fn = _build_artifact_remover(seg_cfg)
 
     # Strip config-only keys that are not segment_tissue() parameters.
     seg_cfg.pop("artifact_exclude_classes", None)

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -15,7 +15,11 @@ logger = logging.getLogger(__name__)
 from mussel.utils import (filter_features, is_remote_path, load_classifier,
                           load_features_from_h5, safe_path_join, save_features,
                           save_hdf5, save_torch_tensor)
-from mussel.utils.artifact_removal import GrandQCArtifactRemover
+from mussel.utils.artifact_removal import (
+    EXCLUDE_ALL_ARTIFACTS,
+    EXCLUDE_PENMARKS_ONLY,
+    GrandQCArtifactRemover,
+)
 from mussel.utils.segment import (draw_slide_mask, save_patches_png,
                                   segment_tissue)
 
@@ -83,17 +87,24 @@ def _tessellate_and_filter(
 
     if artifact_remover_fn is None:
         if seg_cfg.get("remove_artifacts") or seg_cfg.get("remove_penmarks"):
-            artifact_remover_fn = GrandQCArtifactRemover(
-                remove_penmarks_only=(
-                    bool(seg_cfg.get("remove_penmarks"))
-                    and not bool(seg_cfg.get("remove_artifacts"))
-                )
-            )
+            explicit = seg_cfg.get("artifact_exclude_classes")
+            if explicit:
+                exclude_classes = frozenset(int(c) for c in explicit)
+            elif bool(seg_cfg.get("remove_artifacts")):
+                exclude_classes = EXCLUDE_ALL_ARTIFACTS
+            else:
+                exclude_classes = EXCLUDE_PENMARKS_ONLY
+            artifact_remover_fn = GrandQCArtifactRemover(exclude_classes=exclude_classes)
             logger.info(
-                "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s",
+                "Artifact removal enabled: remove_artifacts=%s remove_penmarks=%s "
+                "exclude_classes=%s",
                 seg_cfg.get("remove_artifacts"),
                 seg_cfg.get("remove_penmarks"),
+                sorted(exclude_classes),
             )
+
+    # Strip config-only keys that are not segment_tissue() parameters.
+    seg_cfg.pop("artifact_exclude_classes", None)
 
     if values := segment_tissue(
         slide_path=slide_path,

--- a/mussel/utils/artifact_removal.py
+++ b/mussel/utils/artifact_removal.py
@@ -13,12 +13,21 @@ Model weights are downloaded automatically from
 Requires the ``torch-gpu`` or ``torch-cpu`` extra::
 
     uv sync --extra torch-gpu
+
+Class constants and preset exclusion sets are exported at module level::
+
+    from mussel.utils.artifact_removal import (
+        CLASS_PEN_MARKING, CLASS_BACKGROUND,
+        EXCLUDE_PENMARKS_ONLY, EXCLUDE_ALL_ARTIFACTS,
+        GrandQCArtifactRemover,
+    )
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Optional
+import warnings
+from typing import FrozenSet, Optional
 
 import numpy as np
 
@@ -32,51 +41,155 @@ _GRANDQC_TARGET_MPP = 1.0  # model trained at 10x ≈ 1 µm/px
 _GRANDQC_TILE_SIZE = 512
 _GRANDQC_N_CLASSES = 8
 
-# Output class indices (0-indexed) as labelled in the GrandQC paper
-_CLASS_NORMAL_TISSUE = 1
-_CLASS_PEN_MARKING = 4
-_CLASS_BACKGROUND = 7
+# ---------------------------------------------------------------------------
+# Public GrandQC output class indices (0-indexed, as labelled in the paper).
+# ---------------------------------------------------------------------------
+
+#: Glass / clear-slide background.
+CLASS_GLASS: int = 0
+#: Normal (stained) tissue.
+CLASS_NORMAL_TISSUE: int = 1
+#: Blood / haemorrhage.
+CLASS_BLOOD: int = 2
+#: Necrosis.
+CLASS_NECROSIS: int = 3
+#: Pen marking.
+CLASS_PEN_MARKING: int = 4
+#: Tissue fold.
+CLASS_FOLD: int = 5
+#: Hole or physical slide damage.
+CLASS_HOLE: int = 6
+#: Non-tissue background.
+CLASS_BACKGROUND: int = 7
+
+# ---------------------------------------------------------------------------
+# Preset exclusion sets — pass as ``exclude_classes`` to GrandQCArtifactRemover.
+# ---------------------------------------------------------------------------
+
+#: Conservative: remove only pen markings and background.
+#: Keeps blood, necrosis, folds and holes as tissue.
+#: Recommended default to avoid removing out-of-distribution tissue types.
+EXCLUDE_PENMARKS_ONLY: FrozenSet[int] = frozenset(
+    {CLASS_PEN_MARKING, CLASS_BACKGROUND}
+)
+
+#: Moderate: also remove folds and physical damage, but keep blood and necrosis.
+EXCLUDE_FOLDS_AND_PENMARKS: FrozenSet[int] = frozenset(
+    {CLASS_PEN_MARKING, CLASS_FOLD, CLASS_HOLE, CLASS_BACKGROUND}
+)
+
+#: Aggressive: remove all non-normal-tissue classes.
+#: May over-remove tissue in slides with significant necrosis or haemorrhage
+#: (e.g. glioblastoma, high-grade sarcoma).
+EXCLUDE_ALL_ARTIFACTS: FrozenSet[int] = frozenset(
+    {
+        CLASS_BLOOD,
+        CLASS_NECROSIS,
+        CLASS_PEN_MARKING,
+        CLASS_FOLD,
+        CLASS_HOLE,
+        CLASS_BACKGROUND,
+    }
+)
+
+# Private aliases kept for internal backward compat.
+_CLASS_NORMAL_TISSUE = CLASS_NORMAL_TISSUE
+_CLASS_PEN_MARKING = CLASS_PEN_MARKING
+_CLASS_BACKGROUND = CLASS_BACKGROUND
 
 
 class GrandQCArtifactRemover:
     """Removes artifacts and/or pen marks from a binary tissue mask.
 
     Uses the GrandQC U-Net (EfficientNet-B0 encoder) to classify each pixel
-    of the slide thumbnail into tissue vs artifact categories.  Artifact
-    regions are zeroed out from the existing binary tissue mask.
+    of the slide thumbnail, then zeros out any masked region whose predicted
+    class is in ``exclude_classes``.
 
     Implements the ``artifact_remover_fn(img, mask, mpp) -> mask`` protocol
     expected by :func:`~mussel.utils.segment.segment_tissue`.
 
+    GrandQC output classes (0-indexed):
+        0 – :data:`CLASS_GLASS`         — glass / clear-slide background
+        1 – :data:`CLASS_NORMAL_TISSUE` — normal stained tissue
+        2 – :data:`CLASS_BLOOD`         — blood / haemorrhage
+        3 – :data:`CLASS_NECROSIS`      — necrosis
+        4 – :data:`CLASS_PEN_MARKING`   — pen marking
+        5 – :data:`CLASS_FOLD`          — tissue fold
+        6 – :data:`CLASS_HOLE`          — hole / physical slide damage
+        7 – :data:`CLASS_BACKGROUND`    — non-tissue background
+
     Args:
-        remove_penmarks_only: If ``True``, only pen markings and background
-            are suppressed; folds, dark spots, etc. are kept.  If ``False``
-            (default), all non-normal-tissue classes are removed.
+        exclude_classes: Set of GrandQC class indices to remove from the
+            tissue mask.  Defaults to :data:`EXCLUDE_PENMARKS_ONLY`
+            ``{CLASS_PEN_MARKING, CLASS_BACKGROUND}`` — a conservative
+            setting that keeps blood, necrosis and folds as tissue.
+            Use :data:`EXCLUDE_ALL_ARTIFACTS` for aggressive removal, or
+            build a custom set from the ``CLASS_*`` constants.
         device: Torch device string (e.g. ``"cuda"``, ``"cpu"``).  Defaults
             to CUDA if available.
         batch_size: Number of 512 × 512 tiles to process per forward pass.
+        max_input_mpp: Input thumbnails coarser than this µm/px value are
+            rejected (mask returned unchanged).  Default ``8.0``.
+        remove_penmarks_only: **Deprecated** — use ``exclude_classes``
+            instead.  ``True`` maps to :data:`EXCLUDE_PENMARKS_ONLY`;
+            ``False`` maps to :data:`EXCLUDE_ALL_ARTIFACTS`.
 
-    Example::
+    Examples::
 
-        from mussel.utils.artifact_removal import GrandQCArtifactRemover
-        from mussel.utils.segment import segment_tissue
+        from mussel.utils.artifact_removal import (
+            GrandQCArtifactRemover,
+            EXCLUDE_PENMARKS_ONLY,
+            EXCLUDE_FOLDS_AND_PENMARKS,
+            EXCLUDE_ALL_ARTIFACTS,
+            CLASS_BLOOD, CLASS_PEN_MARKING, CLASS_BACKGROUND,
+        )
 
+        # Conservative (default): pen marks + background only
         remover = GrandQCArtifactRemover()
-        segment_tissue(
-            slide_path="slide.svs",
-            remove_artifacts=True,
-            artifact_remover_fn=remover,
+
+        # Moderate: also remove folds and holes
+        remover = GrandQCArtifactRemover(exclude_classes=EXCLUDE_FOLDS_AND_PENMARKS)
+
+        # Aggressive: everything except normal tissue
+        remover = GrandQCArtifactRemover(exclude_classes=EXCLUDE_ALL_ARTIFACTS)
+
+        # Custom: blood and pen marks only
+        remover = GrandQCArtifactRemover(
+            exclude_classes=frozenset({CLASS_BLOOD, CLASS_PEN_MARKING, CLASS_BACKGROUND})
         )
     """
 
     def __init__(
         self,
-        remove_penmarks_only: bool = False,
+        exclude_classes: Optional[FrozenSet[int]] = None,
+        *,
         device: Optional[str] = None,
         batch_size: int = 8,
         max_input_mpp: float = 8.0,
+        # Deprecated parameter kept for backward compatibility.
+        remove_penmarks_only: Optional[bool] = None,
     ) -> None:
-        self.remove_penmarks_only = remove_penmarks_only
+        if remove_penmarks_only is not None:
+            warnings.warn(
+                "GrandQCArtifactRemover: 'remove_penmarks_only' is deprecated and will be "
+                "removed in a future release.  Use 'exclude_classes' instead:\n"
+                "  remove_penmarks_only=True  → exclude_classes=EXCLUDE_PENMARKS_ONLY\n"
+                "  remove_penmarks_only=False → exclude_classes=EXCLUDE_ALL_ARTIFACTS",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if exclude_classes is None:
+                exclude_classes = (
+                    EXCLUDE_PENMARKS_ONLY
+                    if remove_penmarks_only
+                    else EXCLUDE_ALL_ARTIFACTS
+                )
+
+        self.exclude_classes: FrozenSet[int] = (
+            frozenset(exclude_classes)
+            if exclude_classes is not None
+            else EXCLUDE_PENMARKS_ONLY
+        )
         self.batch_size = batch_size
         self.max_input_mpp = max_input_mpp
         self._device: Optional[str] = device
@@ -148,7 +261,9 @@ class GrandQCArtifactRemover:
             mpp:  Microns-per-pixel of ``img``.
 
         Returns:
-            Corrected binary mask of the same shape and dtype as ``mask``.
+            Corrected binary mask of the same shape and dtype as ``mask``,
+            with pixels belonging to any class in :attr:`exclude_classes`
+            zeroed out.
         """
         import cv2
         import torch
@@ -194,6 +309,11 @@ class GrandQCArtifactRemover:
         ph, pw = img_padded.shape[:2]
         n_h, n_w = ph // tile, pw // tile
 
+        # Pre-build the exclude tensor once for this call.
+        exclude_tensor = torch.tensor(
+            sorted(self.exclude_classes), dtype=torch.long, device=self.device
+        )
+
         # Extract tiles and apply ImageNet normalisation.
         tiles = [
             self._transforms(
@@ -215,10 +335,7 @@ class GrandQCArtifactRemover:
                 logits = self._model(batch)
                 probs = torch.softmax(logits, dim=1)
                 _, cls = torch.max(probs, dim=1)  # (B, tile, tile)
-                if self.remove_penmarks_only:
-                    keep = ~((cls == _CLASS_PEN_MARKING) | (cls == _CLASS_BACKGROUND))
-                else:
-                    keep = cls <= _CLASS_NORMAL_TISSUE
+                keep = ~torch.isin(cls, exclude_tensor)
                 preds.append(keep.cpu().numpy().astype(np.uint8))
 
         # Reassemble tiles into a full prediction map and unpad.

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -816,10 +816,10 @@ def segment_tissue(
                 if removal_fraction >= 1.0 - _MIN_TISSUE_SURVIVAL:
                     logger.warning(
                         "Artifact removal eliminated %.0f%% of tissue for slide %s "
-                        "(threshold: revert if >%.0f%% removed). "
+                        "(threshold: revert if >=%.0f%% removed). "
                         "Falling back to pre-removal mask. "
-                        "Consider using remove_penmarks_only=True or disabling "
-                        "remove_artifacts for this slide type.",
+                        "Consider using artifact_exclude_classes=[4, 7] (pen marks only) "
+                        "or disabling remove_artifacts for this slide type.",
                         removal_fraction * 100,
                         slide_id,
                         (1.0 - _MIN_TISSUE_SURVIVAL) * 100,

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -765,7 +765,7 @@ def segment_tissue(
                 # GrandQC requires ≤ 8 µm/px but the lowest pyramid level is
                 # 8–16 µm/px), read a separate thumbnail at a finer pyramid level.
                 max_mpp = getattr(artifact_remover_fn, "max_input_mpp", None)
-                if max_mpp is not None and img_mpp > max_mpp:
+                if max_mpp is not None and img_mpp >= max_mpp:
                     target_ds = max_mpp / slide_mpp
                     artifact_level = wsi.get_best_level_for_downsample(target_ds)
                     artifact_level_mpp = slide_mpp * level_downsamples[artifact_level][0]
@@ -791,6 +791,7 @@ def segment_tissue(
                             img_mpp,
                         )
 
+                pre_removal_mask = tissue_mask.copy()
                 result_mask = artifact_remover_fn(remover_img, remover_mask, remover_mpp)
 
                 # Resize result back to seg-level dimensions if needed.
@@ -801,7 +802,36 @@ def segment_tissue(
                         (sw, sh),
                         interpolation=cv2.INTER_NEAREST,
                     )
-                tissue_mask = result_mask
+
+                # Fallback: if artifact removal eliminated most or all tissue,
+                # revert to the pre-removal mask.  Over-aggressive removal can
+                # occur when the GrandQC model is out-of-distribution for a
+                # particular tissue type (e.g. necrotic CNS tumours).
+                _MIN_TISSUE_SURVIVAL = 0.10  # at least 10% of original tissue must remain
+                pre_pixels = int(np.count_nonzero(pre_removal_mask))
+                post_pixels = int(np.count_nonzero(result_mask))
+                removal_fraction = (
+                    1.0 - post_pixels / pre_pixels if pre_pixels > 0 else 1.0
+                )
+                if removal_fraction >= 1.0 - _MIN_TISSUE_SURVIVAL:
+                    logger.warning(
+                        "Artifact removal eliminated %.0f%% of tissue for slide %s "
+                        "(threshold: revert if >%.0f%% removed). "
+                        "Falling back to pre-removal mask. "
+                        "Consider using remove_penmarks_only=True or disabling "
+                        "remove_artifacts for this slide type.",
+                        removal_fraction * 100,
+                        slide_id,
+                        (1.0 - _MIN_TISSUE_SURVIVAL) * 100,
+                    )
+                    tissue_mask = pre_removal_mask
+                else:
+                    logger.info(
+                        "Artifact removal: %.0f%% of tissue retained for slide %s.",
+                        (1.0 - removal_fraction) * 100,
+                        slide_id,
+                    )
+                    tissue_mask = result_mask
             else:
                 logger.warning(
                     "artifact_remover_fn was provided but neither remove_artifacts nor "
@@ -832,6 +862,10 @@ def segment_tissue(
             tissue_mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE
         )  # Find contours
         if contours is None or hierarchy is None:
+            logger.warning(
+                "No contours found for slide %s (tissue mask may be empty after artifact removal or segmentation).",
+                slide_id,
+            )
             return None
         hierarchy = np.squeeze(hierarchy, axis=(0,))[:, 2:]
         foreground_contours, hole_contours = _filter_contours(

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -757,7 +757,51 @@ def segment_tissue(
         if artifact_remover_fn is not None:
             if remove_artifacts or remove_penmarks:
                 img_mpp = slide_mpp * level_downsamples[seg_level][0]
-                tissue_mask = artifact_remover_fn(img, tissue_mask, img_mpp)
+                remover_img = img
+                remover_mask = tissue_mask
+                remover_mpp = img_mpp
+
+                # If the seg-level thumbnail is too coarse for the remover (e.g.
+                # GrandQC requires ≤ 8 µm/px but the lowest pyramid level is
+                # 8–16 µm/px), read a separate thumbnail at a finer pyramid level.
+                max_mpp = getattr(artifact_remover_fn, "max_input_mpp", None)
+                if max_mpp is not None and img_mpp > max_mpp:
+                    target_ds = max_mpp / slide_mpp
+                    artifact_level = wsi.get_best_level_for_downsample(target_ds)
+                    artifact_level_mpp = slide_mpp * level_downsamples[artifact_level][0]
+                    if artifact_level_mpp <= max_mpp:
+                        remover_img = np.array(
+                            wsi.read_region(
+                                (0, 0),
+                                artifact_level,
+                                wsi.level_dimensions[artifact_level],
+                            )
+                        )
+                        remover_mpp = artifact_level_mpp
+                        ah, aw = remover_img.shape[:2]
+                        remover_mask = cv2.resize(
+                            tissue_mask, (aw, ah), interpolation=cv2.INTER_NEAREST
+                        )
+                        logger.info(
+                            "Artifact removal: using level %d (%.2f µm/px) instead of "
+                            "seg level %d (%.2f µm/px)",
+                            artifact_level,
+                            remover_mpp,
+                            seg_level,
+                            img_mpp,
+                        )
+
+                result_mask = artifact_remover_fn(remover_img, remover_mask, remover_mpp)
+
+                # Resize result back to seg-level dimensions if needed.
+                if result_mask.shape != tissue_mask.shape:
+                    sh, sw = tissue_mask.shape[:2]
+                    result_mask = cv2.resize(
+                        result_mask.astype(np.uint8),
+                        (sw, sh),
+                        interpolation=cv2.INTER_NEAREST,
+                    )
+                tissue_mask = result_mask
             else:
                 logger.warning(
                     "artifact_remover_fn was provided but neither remove_artifacts nor "

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -246,3 +246,102 @@ def test_artifact_remover_fn_penmarks_only(tmp_path):
         )
 
     MockRemover.assert_called_once_with(remove_penmarks_only=True)
+
+
+def test_artifact_remover_fn_external_instance_reused(tmp_path):
+    """When artifact_remover_fn is supplied externally, GrandQCArtifactRemover is NOT re-instantiated."""
+    from unittest.mock import MagicMock, patch
+    from mussel.cli.tessellate_extract_features_common import _tessellate_and_filter
+    from omegaconf import OmegaConf
+
+    fake_coords = np.array([[0, 0], [512, 0]])
+    external_remover = MagicMock()
+
+    cfg = OmegaConf.create({
+        "seg_config": {
+            "mpp": 0.5,
+            "patch_size": 512,
+            "seg_model": "classic",
+            "remove_artifacts": True,
+            "remove_penmarks": False,
+        },
+        "vis_config": {},
+        "keep_intermediate_files": False,
+        "gpu_device_id": 0,
+        "use_gpu": False,
+        "batch_size": 8,
+        "num_workers": 0,
+        "gpu_device_ids": None,
+    })
+
+    with patch(
+        "mussel.cli.tessellate_extract_features_common.segment_tissue",
+        return_value=(MagicMock(), MagicMock(), fake_coords, None),
+    ) as mock_segment, patch(
+        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
+        autospec=True,
+    ) as MockRemover:
+        _tessellate_and_filter(
+            slide_path="tests/testdata/948176.svs",
+            slide_id="948176",
+            cfg=cfg,
+            temp_dir=str(tmp_path),
+            base_path=tmp_path,
+            use_filtering=False,
+            prefilter_model_type=None,
+            prefilter_model_path=None,
+            skip_second_extraction=False,
+            artifact_remover_fn=external_remover,
+        )
+
+    # Class must NOT be re-instantiated when a remover is provided
+    MockRemover.assert_not_called()
+    # The external remover must be forwarded to segment_tissue
+    _, kwargs = mock_segment.call_args
+    assert kwargs.get("artifact_remover_fn") is external_remover
+
+
+def test_segment_tissue_artifact_mpp_escalation(tmp_path):
+    """segment_tissue reads a finer pyramid level when seg-level MPP exceeds max_input_mpp."""
+    import cv2
+    from unittest.mock import MagicMock, call, patch
+    import numpy as np
+    from mussel.utils.segment import segment_tissue
+
+    slide_path = "tests/testdata/948176.svs"
+
+    # A mock artifact remover whose max_input_mpp is very small so the
+    # seg-level thumbnail will always exceed it, triggering escalation.
+    mock_remover = MagicMock()
+    mock_remover.max_input_mpp = 0.001  # force escalation
+
+    # patch wsi internals minimally — segment_tissue opens the real slide file
+    # so we only intercept the artifact remover call and verify the remover
+    # receives a different (lower-level / higher-res) image.
+    called_mpps = []
+
+    def capture_remover(img, mask, mpp):
+        called_mpps.append(mpp)
+        # Return the mask unchanged to keep the test simple
+        return mask.copy()
+
+    mock_remover.side_effect = capture_remover
+
+    # Use a very permissive config so tessellation doesn't fail
+    result = segment_tissue(
+        slide_path=slide_path,
+        seg_model="classic",
+        mpp=0.5,
+        patch_size=512,
+        segment_threshold=0,
+        remove_artifacts=True,
+        artifact_remover_fn=mock_remover,
+        output_h5_path=str(tmp_path / "out.h5"),
+    )
+
+    assert result is not None, "segment_tissue should succeed"
+    # The remover must have been called with an MPP <= max_input_mpp=0.001
+    # — but since level 0 is the finest and may still exceed 0.001, we only
+    # check it was called (escalation was attempted) rather than asserting the
+    # exact mpp value.
+    assert mock_remover.called, "artifact_remover_fn should have been called"

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -86,3 +86,163 @@ def test_seg_config_seg_model_neural():
     """SegConfig accepts seg_model='neural'."""
     cfg = SegConfig(seg_model="neural")
     assert cfg.seg_model == "neural"
+
+
+def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
+    """_tessellate_and_filter instantiates GrandQCArtifactRemover when remove_artifacts=True.
+
+    The remover is passed as artifact_remover_fn to segment_tissue.  Without this
+    fix the flag was silently ignored (segment_tissue warned and did nothing).
+    """
+    from unittest.mock import MagicMock, patch, call
+    from mussel.cli.tessellate_extract_features_common import _tessellate_and_filter
+    from omegaconf import OmegaConf
+
+    fake_coords = np.array([[0, 0], [512, 0]])
+    fake_polygon = MagicMock()
+    fake_grid = MagicMock()
+
+    cfg = OmegaConf.create({
+        "seg_config": {
+            "mpp": 0.5,
+            "patch_size": 512,
+            "seg_model": "classic",
+            "remove_artifacts": True,
+            "remove_penmarks": False,
+        },
+        "vis_config": {},
+        "keep_intermediate_files": False,
+        "gpu_device_id": 0,
+        "use_gpu": False,
+        "batch_size": 8,
+        "num_workers": 0,
+        "gpu_device_ids": None,
+    })
+
+    with patch(
+        "mussel.cli.tessellate_extract_features_common.segment_tissue",
+        return_value=(fake_polygon, fake_grid, fake_coords, None),
+    ) as mock_segment, patch(
+        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
+        autospec=True,
+    ) as MockRemover:
+        mock_remover_instance = MockRemover.return_value
+
+        _tessellate_and_filter(
+            slide_path="tests/testdata/948176.svs",
+            slide_id="948176",
+            cfg=cfg,
+            temp_dir=str(tmp_path),
+            base_path=tmp_path,
+            use_filtering=False,
+            prefilter_model_type=None,
+            prefilter_model_path=None,
+            skip_second_extraction=False,
+        )
+
+    # GrandQCArtifactRemover must have been instantiated with remove_penmarks_only=False
+    MockRemover.assert_called_once_with(remove_penmarks_only=False)
+
+    # segment_tissue must have received the remover instance
+    _, kwargs = mock_segment.call_args
+    assert kwargs.get("artifact_remover_fn") is mock_remover_instance, (
+        "artifact_remover_fn was not passed to segment_tissue"
+    )
+
+
+def test_artifact_remover_fn_not_instantiated_when_flags_false(tmp_path):
+    """_tessellate_and_filter does NOT instantiate GrandQCArtifactRemover by default."""
+    from unittest.mock import MagicMock, patch
+    from mussel.cli.tessellate_extract_features_common import _tessellate_and_filter
+    from omegaconf import OmegaConf
+
+    fake_coords = np.array([[0, 0], [512, 0]])
+
+    cfg = OmegaConf.create({
+        "seg_config": {
+            "mpp": 0.5,
+            "patch_size": 512,
+            "seg_model": "classic",
+            "remove_artifacts": False,
+            "remove_penmarks": False,
+        },
+        "vis_config": {},
+        "keep_intermediate_files": False,
+        "gpu_device_id": 0,
+        "use_gpu": False,
+        "batch_size": 8,
+        "num_workers": 0,
+        "gpu_device_ids": None,
+    })
+
+    with patch(
+        "mussel.cli.tessellate_extract_features_common.segment_tissue",
+        return_value=(MagicMock(), MagicMock(), fake_coords, None),
+    ) as mock_segment, patch(
+        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
+        autospec=True,
+    ) as MockRemover:
+
+        _tessellate_and_filter(
+            slide_path="tests/testdata/948176.svs",
+            slide_id="948176",
+            cfg=cfg,
+            temp_dir=str(tmp_path),
+            base_path=tmp_path,
+            use_filtering=False,
+            prefilter_model_type=None,
+            prefilter_model_path=None,
+            skip_second_extraction=False,
+        )
+
+    MockRemover.assert_not_called()
+    _, kwargs = mock_segment.call_args
+    assert kwargs.get("artifact_remover_fn") is None
+
+
+def test_artifact_remover_fn_penmarks_only(tmp_path):
+    """remove_penmarks=True with remove_artifacts=False → remove_penmarks_only=True."""
+    from unittest.mock import MagicMock, patch
+    from mussel.cli.tessellate_extract_features_common import _tessellate_and_filter
+    from omegaconf import OmegaConf
+
+    fake_coords = np.array([[0, 0], [512, 0]])
+
+    cfg = OmegaConf.create({
+        "seg_config": {
+            "mpp": 0.5,
+            "patch_size": 512,
+            "seg_model": "classic",
+            "remove_artifacts": False,
+            "remove_penmarks": True,
+        },
+        "vis_config": {},
+        "keep_intermediate_files": False,
+        "gpu_device_id": 0,
+        "use_gpu": False,
+        "batch_size": 8,
+        "num_workers": 0,
+        "gpu_device_ids": None,
+    })
+
+    with patch(
+        "mussel.cli.tessellate_extract_features_common.segment_tissue",
+        return_value=(MagicMock(), MagicMock(), fake_coords, None),
+    ), patch(
+        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
+        autospec=True,
+    ) as MockRemover:
+
+        _tessellate_and_filter(
+            slide_path="tests/testdata/948176.svs",
+            slide_id="948176",
+            cfg=cfg,
+            temp_dir=str(tmp_path),
+            base_path=tmp_path,
+            use_filtering=False,
+            prefilter_model_type=None,
+            prefilter_model_path=None,
+            skip_second_extraction=False,
+        )
+
+    MockRemover.assert_called_once_with(remove_penmarks_only=True)

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -94,7 +94,7 @@ def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
     The remover is passed as artifact_remover_fn to segment_tissue.  Without this
     fix the flag was silently ignored (segment_tissue warned and did nothing).
     """
-    from unittest.mock import MagicMock, patch, call
+    from unittest.mock import MagicMock, patch
     from mussel.cli.tessellate_extract_features_common import _tessellate_and_filter
     from omegaconf import OmegaConf
 
@@ -102,30 +102,35 @@ def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
     fake_polygon = MagicMock()
     fake_grid = MagicMock()
 
-    cfg = OmegaConf.create({
-        "seg_config": {
-            "mpp": 0.5,
-            "patch_size": 512,
-            "seg_model": "classic",
-            "remove_artifacts": True,
-            "remove_penmarks": False,
-        },
-        "vis_config": {},
-        "keep_intermediate_files": False,
-        "gpu_device_id": 0,
-        "use_gpu": False,
-        "batch_size": 8,
-        "num_workers": 0,
-        "gpu_device_ids": None,
-    })
+    cfg = OmegaConf.create(
+        {
+            "seg_config": {
+                "mpp": 0.5,
+                "patch_size": 512,
+                "seg_model": "classic",
+                "remove_artifacts": True,
+                "remove_penmarks": False,
+            },
+            "vis_config": {},
+            "keep_intermediate_files": False,
+            "gpu_device_id": 0,
+            "use_gpu": False,
+            "batch_size": 8,
+            "num_workers": 0,
+            "gpu_device_ids": None,
+        }
+    )
 
-    with patch(
-        "mussel.cli.tessellate_extract_features_common.segment_tissue",
-        return_value=(fake_polygon, fake_grid, fake_coords, None),
-    ) as mock_segment, patch(
-        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
-        autospec=True,
-    ) as MockRemover:
+    with (
+        patch(
+            "mussel.cli.tessellate_extract_features_common.segment_tissue",
+            return_value=(fake_polygon, fake_grid, fake_coords, None),
+        ) as mock_segment,
+        patch(
+            "mussel.cli.tessellate.GrandQCArtifactRemover",
+            autospec=True,
+        ) as MockRemover,
+    ):
         mock_remover_instance = MockRemover.return_value
 
         _tessellate_and_filter(
@@ -142,13 +147,14 @@ def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
 
     # GrandQCArtifactRemover must have been instantiated with EXCLUDE_ALL_ARTIFACTS
     from mussel.utils.artifact_removal import EXCLUDE_ALL_ARTIFACTS
+
     MockRemover.assert_called_once_with(exclude_classes=EXCLUDE_ALL_ARTIFACTS)
 
     # segment_tissue must have received the remover instance
     _, kwargs = mock_segment.call_args
-    assert kwargs.get("artifact_remover_fn") is mock_remover_instance, (
-        "artifact_remover_fn was not passed to segment_tissue"
-    )
+    assert (
+        kwargs.get("artifact_remover_fn") is mock_remover_instance
+    ), "artifact_remover_fn was not passed to segment_tissue"
 
 
 def test_artifact_remover_fn_not_instantiated_when_flags_false(tmp_path):
@@ -159,30 +165,35 @@ def test_artifact_remover_fn_not_instantiated_when_flags_false(tmp_path):
 
     fake_coords = np.array([[0, 0], [512, 0]])
 
-    cfg = OmegaConf.create({
-        "seg_config": {
-            "mpp": 0.5,
-            "patch_size": 512,
-            "seg_model": "classic",
-            "remove_artifacts": False,
-            "remove_penmarks": False,
-        },
-        "vis_config": {},
-        "keep_intermediate_files": False,
-        "gpu_device_id": 0,
-        "use_gpu": False,
-        "batch_size": 8,
-        "num_workers": 0,
-        "gpu_device_ids": None,
-    })
+    cfg = OmegaConf.create(
+        {
+            "seg_config": {
+                "mpp": 0.5,
+                "patch_size": 512,
+                "seg_model": "classic",
+                "remove_artifacts": False,
+                "remove_penmarks": False,
+            },
+            "vis_config": {},
+            "keep_intermediate_files": False,
+            "gpu_device_id": 0,
+            "use_gpu": False,
+            "batch_size": 8,
+            "num_workers": 0,
+            "gpu_device_ids": None,
+        }
+    )
 
-    with patch(
-        "mussel.cli.tessellate_extract_features_common.segment_tissue",
-        return_value=(MagicMock(), MagicMock(), fake_coords, None),
-    ) as mock_segment, patch(
-        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
-        autospec=True,
-    ) as MockRemover:
+    with (
+        patch(
+            "mussel.cli.tessellate_extract_features_common.segment_tissue",
+            return_value=(MagicMock(), MagicMock(), fake_coords, None),
+        ) as mock_segment,
+        patch(
+            "mussel.cli.tessellate.GrandQCArtifactRemover",
+            autospec=True,
+        ) as MockRemover,
+    ):
 
         _tessellate_and_filter(
             slide_path="tests/testdata/948176.svs",
@@ -209,30 +220,35 @@ def test_artifact_remover_fn_penmarks_only(tmp_path):
 
     fake_coords = np.array([[0, 0], [512, 0]])
 
-    cfg = OmegaConf.create({
-        "seg_config": {
-            "mpp": 0.5,
-            "patch_size": 512,
-            "seg_model": "classic",
-            "remove_artifacts": False,
-            "remove_penmarks": True,
-        },
-        "vis_config": {},
-        "keep_intermediate_files": False,
-        "gpu_device_id": 0,
-        "use_gpu": False,
-        "batch_size": 8,
-        "num_workers": 0,
-        "gpu_device_ids": None,
-    })
+    cfg = OmegaConf.create(
+        {
+            "seg_config": {
+                "mpp": 0.5,
+                "patch_size": 512,
+                "seg_model": "classic",
+                "remove_artifacts": False,
+                "remove_penmarks": True,
+            },
+            "vis_config": {},
+            "keep_intermediate_files": False,
+            "gpu_device_id": 0,
+            "use_gpu": False,
+            "batch_size": 8,
+            "num_workers": 0,
+            "gpu_device_ids": None,
+        }
+    )
 
-    with patch(
-        "mussel.cli.tessellate_extract_features_common.segment_tissue",
-        return_value=(MagicMock(), MagicMock(), fake_coords, None),
-    ), patch(
-        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
-        autospec=True,
-    ) as MockRemover:
+    with (
+        patch(
+            "mussel.cli.tessellate_extract_features_common.segment_tissue",
+            return_value=(MagicMock(), MagicMock(), fake_coords, None),
+        ),
+        patch(
+            "mussel.cli.tessellate.GrandQCArtifactRemover",
+            autospec=True,
+        ) as MockRemover,
+    ):
 
         _tessellate_and_filter(
             slide_path="tests/testdata/948176.svs",
@@ -247,6 +263,7 @@ def test_artifact_remover_fn_penmarks_only(tmp_path):
         )
 
     from mussel.utils.artifact_removal import EXCLUDE_PENMARKS_ONLY
+
     MockRemover.assert_called_once_with(exclude_classes=EXCLUDE_PENMARKS_ONLY)
 
 
@@ -259,30 +276,35 @@ def test_artifact_remover_fn_external_instance_reused(tmp_path):
     fake_coords = np.array([[0, 0], [512, 0]])
     external_remover = MagicMock()
 
-    cfg = OmegaConf.create({
-        "seg_config": {
-            "mpp": 0.5,
-            "patch_size": 512,
-            "seg_model": "classic",
-            "remove_artifacts": True,
-            "remove_penmarks": False,
-        },
-        "vis_config": {},
-        "keep_intermediate_files": False,
-        "gpu_device_id": 0,
-        "use_gpu": False,
-        "batch_size": 8,
-        "num_workers": 0,
-        "gpu_device_ids": None,
-    })
+    cfg = OmegaConf.create(
+        {
+            "seg_config": {
+                "mpp": 0.5,
+                "patch_size": 512,
+                "seg_model": "classic",
+                "remove_artifacts": True,
+                "remove_penmarks": False,
+            },
+            "vis_config": {},
+            "keep_intermediate_files": False,
+            "gpu_device_id": 0,
+            "use_gpu": False,
+            "batch_size": 8,
+            "num_workers": 0,
+            "gpu_device_ids": None,
+        }
+    )
 
-    with patch(
-        "mussel.cli.tessellate_extract_features_common.segment_tissue",
-        return_value=(MagicMock(), MagicMock(), fake_coords, None),
-    ) as mock_segment, patch(
-        "mussel.cli.tessellate_extract_features_common.GrandQCArtifactRemover",
-        autospec=True,
-    ) as MockRemover:
+    with (
+        patch(
+            "mussel.cli.tessellate_extract_features_common.segment_tissue",
+            return_value=(MagicMock(), MagicMock(), fake_coords, None),
+        ) as mock_segment,
+        patch(
+            "mussel.cli.tessellate.GrandQCArtifactRemover",
+            autospec=True,
+        ) as MockRemover,
+    ):
         _tessellate_and_filter(
             slide_path="tests/testdata/948176.svs",
             slide_id="948176",
@@ -394,9 +416,9 @@ def test_segment_tissue_artifact_mpp_exact_equality_escalates(tmp_path):
     assert result is not None, "segment_tissue should succeed"
     assert mock_remover.called, "artifact_remover_fn should have been called"
     # After escalation, the remover is called with an MPP <= exact_mpp.
-    assert called_mpps[0] <= exact_mpp, (
-        f"Remover should be called at MPP <= {exact_mpp}, got {called_mpps[0]}"
-    )
+    assert (
+        called_mpps[0] <= exact_mpp
+    ), f"Remover should be called at MPP <= {exact_mpp}, got {called_mpps[0]}"
 
 
 def test_segment_tissue_artifact_removal_empty_mask_fallback(tmp_path):
@@ -428,6 +450,6 @@ def test_segment_tissue_artifact_removal_empty_mask_fallback(tmp_path):
     )
 
     # Should not crash; should fall back and produce a valid result
-    assert result is not None, (
-        "segment_tissue should fall back to pre-removal mask when artifact removal empties it"
-    )
+    assert (
+        result is not None
+    ), "segment_tissue should fall back to pre-removal mask when artifact removal empties it"

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -140,8 +140,9 @@ def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
             skip_second_extraction=False,
         )
 
-    # GrandQCArtifactRemover must have been instantiated with remove_penmarks_only=False
-    MockRemover.assert_called_once_with(remove_penmarks_only=False)
+    # GrandQCArtifactRemover must have been instantiated with EXCLUDE_ALL_ARTIFACTS
+    from mussel.utils.artifact_removal import EXCLUDE_ALL_ARTIFACTS
+    MockRemover.assert_called_once_with(exclude_classes=EXCLUDE_ALL_ARTIFACTS)
 
     # segment_tissue must have received the remover instance
     _, kwargs = mock_segment.call_args
@@ -245,7 +246,8 @@ def test_artifact_remover_fn_penmarks_only(tmp_path):
             skip_second_extraction=False,
         )
 
-    MockRemover.assert_called_once_with(remove_penmarks_only=True)
+    from mussel.utils.artifact_removal import EXCLUDE_PENMARKS_ONLY
+    MockRemover.assert_called_once_with(exclude_classes=EXCLUDE_PENMARKS_ONLY)
 
 
 def test_artifact_remover_fn_external_instance_reused(tmp_path):
@@ -345,3 +347,87 @@ def test_segment_tissue_artifact_mpp_escalation(tmp_path):
     # check it was called (escalation was attempted) rather than asserting the
     # exact mpp value.
     assert mock_remover.called, "artifact_remover_fn should have been called"
+
+
+def test_segment_tissue_artifact_mpp_exact_equality_escalates(tmp_path):
+    """segment_tissue escalates when seg-level MPP equals max_input_mpp (>= not just >)."""
+    from unittest.mock import MagicMock
+    import numpy as np
+    import tiffslide
+    from mussel.utils.segment import segment_tissue
+
+    slide_path = "tests/testdata/948176.svs"
+
+    # Compute the actual seg-level MPP using tiffslide (available in venv).
+    wsi = tiffslide.TiffSlide(slide_path)
+    slide_mpp = float(
+        wsi.properties.get("tiffslide.mpp-x")
+        or wsi.properties.get("openslide.mpp-x")
+        or 0.5
+    )
+    seg_level = len(wsi.level_dimensions) - 1
+    downsample = wsi.level_downsamples[seg_level]
+    exact_mpp = slide_mpp * downsample
+    wsi.close()
+
+    called_mpps = []
+    mock_remover = MagicMock()
+    mock_remover.max_input_mpp = exact_mpp  # exactly equal → should still escalate
+
+    def capture_remover(img, mask, mpp):
+        called_mpps.append(mpp)
+        return mask.copy()
+
+    mock_remover.side_effect = capture_remover
+
+    result = segment_tissue(
+        slide_path=slide_path,
+        seg_model="classic",
+        mpp=0.5,
+        patch_size=512,
+        segment_threshold=0,
+        remove_artifacts=True,
+        artifact_remover_fn=mock_remover,
+        output_h5_path=str(tmp_path / "out.h5"),
+    )
+
+    assert result is not None, "segment_tissue should succeed"
+    assert mock_remover.called, "artifact_remover_fn should have been called"
+    # After escalation, the remover is called with an MPP <= exact_mpp.
+    assert called_mpps[0] <= exact_mpp, (
+        f"Remover should be called at MPP <= {exact_mpp}, got {called_mpps[0]}"
+    )
+
+
+def test_segment_tissue_artifact_removal_empty_mask_fallback(tmp_path):
+    """When artifact removal returns an all-zero mask, segment_tissue falls back to the pre-removal mask."""
+    from unittest.mock import MagicMock
+    import numpy as np
+    from mussel.utils.segment import segment_tissue
+
+    slide_path = "tests/testdata/948176.svs"
+
+    mock_remover = MagicMock()
+    mock_remover.max_input_mpp = 1000.0  # no escalation needed
+
+    def zero_mask_remover(img, mask, mpp):
+        # Simulate over-aggressive removal: return all-zeros
+        return np.zeros_like(mask)
+
+    mock_remover.side_effect = zero_mask_remover
+
+    result = segment_tissue(
+        slide_path=slide_path,
+        seg_model="classic",
+        mpp=0.5,
+        patch_size=512,
+        segment_threshold=0,
+        remove_artifacts=True,
+        artifact_remover_fn=mock_remover,
+        output_h5_path=str(tmp_path / "out.h5"),
+    )
+
+    # Should not crash; should fall back and produce a valid result
+    assert result is not None, (
+        "segment_tissue should fall back to pre-removal mask when artifact removal empties it"
+    )

--- a/tests/mussel/utils/test_artifact_removal.py
+++ b/tests/mussel/utils/test_artifact_removal.py
@@ -14,10 +14,15 @@ import torch
 
 
 def _make_remover(remove_penmarks_only: bool = False):
-    from mussel.utils.artifact_removal import GrandQCArtifactRemover
+    from mussel.utils.artifact_removal import (
+        EXCLUDE_ALL_ARTIFACTS,
+        EXCLUDE_PENMARKS_ONLY,
+        GrandQCArtifactRemover,
+    )
 
+    exclude_classes = EXCLUDE_PENMARKS_ONLY if remove_penmarks_only else EXCLUDE_ALL_ARTIFACTS
     return GrandQCArtifactRemover(
-        remove_penmarks_only=remove_penmarks_only,
+        exclude_classes=exclude_classes,
         device="cpu",
         batch_size=4,
     )

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -743,15 +743,38 @@ class TestTissueAreaThresholdScaling:
             assert len(coords) > 0, f"Expected patches at ds={ds}"
 
 
+def _make_mock_wsi_with_real_tissue(width=4096, height=4096):
+    """Return a mock WSI where the bottom half is pink (tissue) and top half white (bg).
+
+    HSV saturation of the pink pixels (~127) exceeds the default segment_threshold (20),
+    so segment_tissue detects real tissue in the lower half of the slide.
+    """
+    mock_wsi = MagicMock()
+    mock_wsi.level_dimensions = [(width, height), (width // 4, height // 4)]
+    mock_wsi.level_downsamples = [1.0, 4.0]
+    mock_wsi.get_best_level_for_downsample.return_value = 1
+    h, w = height // 4, width // 4
+    thumb = np.ones((h, w, 3), dtype=np.uint8) * 255  # white background
+    # Bottom half: pink — HSV saturation ≈ 127 > segment_threshold(20) → detected as tissue
+    thumb[h // 2 :, :] = [210, 100, 140]
+    mock_wsi.read_region.return_value = thumb
+    return mock_wsi
+
+
 def _make_mock_wsi_with_tissue(width=4096, height=4096):
-    """Return a mock WSI that produces a solid-white 64×64 thumbnail (all tissue)."""
+    """Return a mock WSI that produces a uniform-gray thumbnail (no real tissue).
+
+    The classic segmenter thresholds on HSV saturation; a uniform gray image
+    has S=0, so the tissue mask is all-zero.  Tests that need actual tissue
+    should use _make_mock_wsi_with_real_tissue() instead.
+    """
     import numpy as np
 
     mock_wsi = MagicMock()
     mock_wsi.level_dimensions = [(width, height), (width // 4, height // 4)]
     mock_wsi.level_downsamples = [1.0, 4.0]
     mock_wsi.get_best_level_for_downsample.return_value = 1
-    # Solid white thumbnail → tissue everywhere after Otsu threshold
+    # Solid gray thumbnail — saturation=0 → no tissue detected by classic segmenter
     thumb = np.ones((height // 4, width // 4, 3), dtype=np.uint8) * 200
     mock_wsi.read_region.return_value = thumb
     return mock_wsi
@@ -1043,6 +1066,224 @@ class TestSegmentTissueArtifactRemover:
             )
 
         assert any("artifact_remover_fn" in msg for msg in caplog.messages)
+
+    def test_tissue_survival_fallback_reverts_mask(self, caplog):
+        """When remover eliminates >=90% of tissue, pre-removal mask is kept."""
+        import logging
+
+        def wipeout_remover(img, mask, mpp):
+            return np.zeros_like(mask)
+
+        mock_wsi = _make_mock_wsi_with_real_tissue()
+
+        with caplog.at_level(logging.WARNING, logger="mussel.utils.segment"):
+            result = _run_segment_with_mocks(
+                mock_wsi,
+                patch_size=256,
+                mpp=0.5,
+                tissue_area_threshold=1,
+                remove_artifacts=True,
+                artifact_remover_fn=wipeout_remover,
+            )
+
+        # Warning must mention the fallback with correct symbols and API
+        assert any(
+            "Falling back to pre-removal mask" in msg for msg in caplog.messages
+        ), "Expected fallback warning in log"
+        assert any(
+            "artifact_exclude_classes=[4, 7]" in msg for msg in caplog.messages
+        ), "Warning should reference artifact_exclude_classes=[4, 7], not deprecated remove_penmarks_only"
+        assert any(
+            ">=90" in msg for msg in caplog.messages
+        ), "Warning should use >= symbol in threshold message"
+
+        # Fallback reverts to pre-removal mask → tissue still present → patches found
+        assert result is not None, "segment_tissue should not return None after fallback"
+        _, _, coords, _ = result
+        assert len(coords) > 0, "Pre-removal mask should yield patches after fallback"
+
+    def test_tissue_survival_normal_path_uses_result_mask(self):
+        """When remover keeps >=10% of tissue, the result mask is applied (no fallback)."""
+        call_count = []
+
+        def half_remover(img, mask, mpp):
+            call_count.append(1)
+            # Zero the top half — keeps bottom 50% of tissue, well above 10% survival
+            result = mask.copy()
+            result[: result.shape[0] // 2, :] = 0
+            return result
+
+        # Full-tissue mock — tissue in the bottom half only (the other half is bg already)
+        mock_wsi = _make_mock_wsi_with_real_tissue()
+
+        result_with_removal = _run_segment_with_mocks(
+            mock_wsi,
+            patch_size=256,
+            mpp=0.5,
+            tissue_area_threshold=1,
+            remove_artifacts=True,
+            artifact_remover_fn=half_remover,
+        )
+
+        assert len(call_count) == 1, "remover should have been called exactly once"
+        # half_remover only keeps bottom tissue → should still produce some patches
+        assert result_with_removal is not None, "Should not return None when tissue survives"
+
+    def test_tissue_survival_boundary_at_exactly_90pct_triggers_fallback(self, caplog):
+        """Removal fraction == 0.90 (exactly at threshold) should trigger fallback."""
+        import logging
+
+        def exactly_90pct_remover(img, mask, mpp):
+            # Zero out exactly 90% of the nonzero pixels using ceil so we hit exactly >=90%
+            import math
+            flat = mask.flatten()
+            nonzero_idx = np.flatnonzero(flat)
+            n_to_zero = math.ceil(len(nonzero_idx) * 0.90)
+            flat[nonzero_idx[:n_to_zero]] = 0
+            return flat.reshape(mask.shape)
+
+        mock_wsi = _make_mock_wsi_with_real_tissue()
+
+        with caplog.at_level(logging.WARNING, logger="mussel.utils.segment"):
+            _run_segment_with_mocks(
+                mock_wsi,
+                patch_size=256,
+                mpp=0.5,
+                tissue_area_threshold=1,
+                remove_artifacts=True,
+                artifact_remover_fn=exactly_90pct_remover,
+            )
+
+        assert any(
+            "Falling back to pre-removal mask" in msg for msg in caplog.messages
+        ), "Exactly 90% removal should trigger fallback (>= threshold)"
+
+    def test_tissue_survival_pre_pixels_zero_triggers_fallback(self, caplog):
+        """When pre-removal mask is all-zero, removal_fraction == 1.0 → fallback triggered."""
+        import logging
+
+        call_count = []
+
+        def pass_through_remover(img, mask, mpp):
+            call_count.append(1)
+            return mask  # returns all-zero → same as input
+
+        # All-gray uniform image → saturation channel = 0 → tissue mask is all-zero
+        # (classic segmenter thresholds on HSV saturation; gray has S=0 < threshold=20)
+        mock_wsi = _make_mock_wsi_with_tissue()  # uniform-gray → no tissue after segmentation
+
+        with caplog.at_level(logging.WARNING, logger="mussel.utils.segment"):
+            _run_segment_with_mocks(
+                mock_wsi,
+                patch_size=256,
+                mpp=0.5,
+                tissue_area_threshold=1,
+                remove_artifacts=True,
+                artifact_remover_fn=pass_through_remover,
+            )
+
+        # Remover IS called even when tissue mask is all-zero (no early-return before remover block)
+        assert len(call_count) == 1, "remover is called regardless of tissue mask content"
+        # pre_pixels=0 → removal_fraction=1.0 → fallback triggered
+        assert any(
+            "Falling back to pre-removal mask" in msg for msg in caplog.messages
+        ), "pre_pixels=0 should set removal_fraction=1.0 and trigger the fallback"
+
+    def test_mpp_escalation_uses_finer_level(self):
+        """When img_mpp >= remover.max_input_mpp, a finer pyramid level is read."""
+        import numpy as np
+
+        call_args = []
+
+        def mpp_checking_remover(img, mask, mpp):
+            call_args.append({"img_shape": img.shape, "mask_shape": mask.shape, "mpp": mpp})
+            return mask
+
+        mpp_checking_remover.max_input_mpp = 4.0  # requires <= 4 µm/px
+
+        # WSI with slide_mpp=0.5; seg_level=1 has downsample=8 → img_mpp=4.0 → triggers escalation
+        # Escalation picks level 0 (downsample=1 → mpp=0.5 <= 4.0)
+        mock_wsi = MagicMock()
+        mock_wsi.level_dimensions = [(4096, 4096), (512, 512)]
+        mock_wsi.level_downsamples = [1.0, 8.0]
+        # get_best_level_for_downsample(4.0/0.5=8) → returns level 1 (ds=8 → mpp=4.0)
+        # but 4.0 <= 4.0 so it IS fine — try with a coarser seg level
+        mock_wsi.get_best_level_for_downsample.return_value = 0  # escalate to level 0
+        fine_thumb = np.ones((4096, 4096, 3), dtype=np.uint8) * 200
+
+        def smart_read(origin, level, dims):
+            if level == 0:
+                return fine_thumb
+            coarse = np.ones((512, 512, 3), dtype=np.uint8) * 200
+            return coarse
+
+        mock_wsi.read_region.side_effect = smart_read
+
+        from mussel.utils.segment import segment_tissue
+        from unittest.mock import patch as _patch
+
+        with (
+            _patch("mussel.utils.segment.tiffslide.open_slide", return_value=mock_wsi),
+            _patch("mussel.utils.segment.get_slide_mpp", return_value=0.5),
+            _patch(
+                "mussel.utils.segment._assert_level_downsamples",
+                return_value=[(1.0, 1.0), (8.0, 8.0)],
+            ),
+        ):
+            segment_tissue(
+                "/fake/slide.svs",
+                patch_size=256,
+                mpp=0.5,
+                seg_level=1,
+                tissue_area_threshold=1,
+                remove_artifacts=True,
+                artifact_remover_fn=mpp_checking_remover,
+            )
+
+        assert len(call_args) == 1, "remover should be called once"
+        # At escalation, level 0 mpp = 0.5 * 1.0 = 0.5 < max_input_mpp=4.0
+        assert call_args[0]["mpp"] == pytest.approx(0.5), (
+            f"Expected escalated mpp=0.5, got {call_args[0]['mpp']}"
+        )
+        # The fine-level image should be larger than the 512×512 coarse seg thumbnail
+        assert call_args[0]["img_shape"][0] == 4096, (
+            "Remover should receive the finer-level thumbnail, not the coarse seg thumbnail"
+        )
+
+    def test_mpp_escalation_skipped_when_img_mpp_below_max(self):
+        """When img_mpp < max_input_mpp, the seg-level thumbnail is used directly."""
+        import numpy as np
+
+        call_args = []
+
+        def mpp_checking_remover(img, mask, mpp):
+            call_args.append({"img_shape": img.shape, "mpp": mpp})
+            return mask
+
+        mpp_checking_remover.max_input_mpp = 16.0  # very permissive — seg level is fine
+
+        # seg_level=1 with downsample=4 and slide_mpp=0.5 → img_mpp=2.0 < 16.0
+        mock_wsi = _make_mock_wsi_with_tissue()  # level_downsamples=[1.0, 4.0]
+
+        _run_segment_with_mocks(
+            mock_wsi,
+            patch_size=256,
+            mpp=0.5,
+            seg_level=1,
+            tissue_area_threshold=1,
+            remove_artifacts=True,
+            artifact_remover_fn=mpp_checking_remover,
+        )
+
+        assert len(call_args) == 1
+        # img_mpp = 0.5 * 4.0 = 2.0 (seg level, not escalated)
+        assert call_args[0]["mpp"] == pytest.approx(2.0), (
+            f"Expected seg-level mpp=2.0, got {call_args[0]['mpp']}"
+        )
+        # Thumbnail should be 1024×1024 (4096/4), the seg-level size
+        assert call_args[0]["img_shape"][0] == 1024, (
+            "Should use seg-level thumbnail when mpp is within limit"
+        )
 
 
 class TestSegmentTissueSegModel:


### PR DESCRIPTION
## Summary

This PR fully fixes `GrandQCArtifactRemover` so it genuinely runs during `tessellate_extract_features`, and adds fine-grained control over which tissue classes are removed.

---

### Bug fixes (Issues 1–4)

#### Issue 1 — `artifact_remover_fn` was never wired in

`SegConfig.remove_artifacts=True` was passed as a plain boolean via `**OmegaConf.to_container(cfg.seg_config)`, but `segment_tissue()` only accepts an `artifact_remover_fn` callable. The remover was never created. Result: a warning was logged and artifact removal was silently skipped on every run.

**Fix**: `_tessellate_and_filter()` now instantiates `GrandQCArtifactRemover` from the config flags and passes it as `artifact_remover_fn` to `segment_tissue()`.

#### Issue 2 — Seg-level thumbnail too coarse for GrandQC

`segment_tissue()` reads a thumbnail at the lowest pyramid level (typically 8–16 µm/px). `GrandQCArtifactRemover` has an internal guard that returns the mask unchanged when `img_mpp > max_input_mpp` (default 8.0 µm/px) — so artifact removal still no-oped even after Issue 1 was fixed.

**Fix**: `segment_tissue()` now checks `img_mpp >= max_input_mpp` and reads a finer pyramid level at or below the threshold. The prediction map is resized back to seg-level mask dimensions with `INTER_NEAREST`. The `>=` (not `>`) handles exact-equality edge cases (e.g. a 0.5 µm/px slide at 16× downsample is exactly 8.0 µm/px).

#### Issue 3 — GrandQC weights downloaded once per slide

`GrandQCArtifactRemover` was instantiated inside `_tessellate_and_filter()`, which is called per slide. Weights are re-downloaded from HuggingFace on each new instantiation — causing latency and occasional timeouts for later slides in a batch.

**Fix**: Added `_build_artifact_remover(cfg)` helper. Both `_main_single` and `_main_batch` create one shared instance and pass it through the call chain.

#### Issue 4 — Silent failure when artifact removal empties the tissue mask

When GrandQC removes all tissue (e.g. out-of-distribution slides, borderline MPP), `cv2.findContours` returns `hierarchy=None`, causing a silent `return None` in `segment_tissue()` — no log, no error.

**Fix**: After calling the artifact remover, the tissue survival fraction is computed. If more than 90% of tissue was removed, the pre-removal mask is used instead and a warning is logged. The previously silent `hierarchy=None` path now also logs a warning.

---

### New feature — Fine-grained class exclusion (`exclude_classes`)

Replaces the `remove_penmarks_only: bool` parameter with `exclude_classes: FrozenSet[int]`.

#### Public class constants

```python
from mussel.utils.artifact_removal import (
    CLASS_GLASS,          # 0 — glass / clear-slide background
    CLASS_NORMAL_TISSUE,  # 1 — normal stained tissue
    CLASS_BLOOD,          # 2 — blood / haemorrhage
    CLASS_NECROSIS,       # 3 — necrosis
    CLASS_PEN_MARKING,    # 4 — pen marking
    CLASS_FOLD,           # 5 — tissue fold
    CLASS_HOLE,           # 6 — hole / physical damage
    CLASS_BACKGROUND,     # 7 — non-tissue background
)
```

#### Preset exclusion sets

| Preset | Classes removed | Use case |
|---|---|---|
| `EXCLUDE_PENMARKS_ONLY` | `{4, 7}` | **Default** — safe for all tissue types |
| `EXCLUDE_FOLDS_AND_PENMARKS` | `{4, 5, 6, 7}` | Also removes folds and holes |
| `EXCLUDE_ALL_ARTIFACTS` | `{2,3,4,5,6,7}` | Aggressive — old default behavior |

#### Usage examples

```python
from mussel.utils.artifact_removal import (
    GrandQCArtifactRemover,
    EXCLUDE_PENMARKS_ONLY, EXCLUDE_FOLDS_AND_PENMARKS, EXCLUDE_ALL_ARTIFACTS,
    CLASS_BLOOD, CLASS_PEN_MARKING, CLASS_BACKGROUND,
)

# Conservative (default): pen marks + background only
remover = GrandQCArtifactRemover()

# Moderate: also remove folds and holes
remover = GrandQCArtifactRemover(exclude_classes=EXCLUDE_FOLDS_AND_PENMARKS)

# Aggressive: everything except normal tissue
remover = GrandQCArtifactRemover(exclude_classes=EXCLUDE_ALL_ARTIFACTS)

# Custom: blood and pen marks only
remover = GrandQCArtifactRemover(
    exclude_classes=frozenset({CLASS_BLOOD, CLASS_PEN_MARKING, CLASS_BACKGROUND})
)
```

#### Config-driven control via `SegConfig.artifact_exclude_classes`

```yaml
# nextflow.config / titan_validation.yaml
tiling:
  remove_penmarks: true          # enable remover
  artifact_exclude_classes:      # explicit class list overrides flag-based preset
    - 4   # pen marking
    - 5   # fold
    - 6   # hole
    - 7   # background
```

Resolution order in `_build_artifact_remover`:
1. `artifact_exclude_classes` list → converted to `frozenset` verbatim
2. `remove_artifacts=True` → `EXCLUDE_ALL_ARTIFACTS`
3. `remove_penmarks=True` only → `EXCLUDE_PENMARKS_ONLY`

#### Backward compatibility

`remove_penmarks_only: bool` still works but emits `DeprecationWarning`:
```
GrandQCArtifactRemover: 'remove_penmarks_only' is deprecated.
  remove_penmarks_only=True  → exclude_classes=EXCLUDE_PENMARKS_ONLY
  remove_penmarks_only=False → exclude_classes=EXCLUDE_ALL_ARTIFACTS
```

---

### Changed files

| File | Change |
|---|---|
| `mussel/utils/artifact_removal.py` | Public `CLASS_*` constants, preset `EXCLUDE_*` sets, `exclude_classes` param, `torch.isin()` inference, deprecation shim |
| `mussel/utils/segment.py` | MPP escalation (`>=`), fraction-based fallback guard (10% survival threshold), warning on silent `hierarchy=None` |
| `mussel/cli/tessellate.py` | Strip `artifact_exclude_classes` from `**seg_cfg` before passing to `segment_tissue()` |
| `mussel/cli/tessellate_extract_features.py` | `_build_artifact_remover()` helper, shared instance in `_main_single` / `_main_batch` |
| `mussel/cli/tessellate_extract_features_common.py` | `artifact_remover_fn` param on 3 functions; resolve `exclude_classes` from config flags |
| `tests/mussel/cli/test_tessellate.py` | 4 existing tests updated to new API; 4 new tests |
| `tests/mussel/utils/test_artifact_removal.py` | Updated to use `exclude_classes` directly |

---

### Tests

All 22 relevant tests pass:

| Test | Covers |
|---|---|
| `test_artifact_remover_fn_wired_when_remove_artifacts` | `EXCLUDE_ALL_ARTIFACTS` when `remove_artifacts=True` |
| `test_artifact_remover_fn_not_instantiated_when_flags_false` | No remover when both flags false |
| `test_artifact_remover_fn_penmarks_only` | `EXCLUDE_PENMARKS_ONLY` when only `remove_penmarks=True` |
| `test_artifact_remover_fn_external_instance_reused` | External instance not re-instantiated |
| `test_segment_tissue_artifact_mpp_escalation` | Finer level read when MPP below threshold |
| `test_segment_tissue_artifact_mpp_exact_equality_escalates` | `>=` edge case: exact MPP equality triggers escalation |
| `test_segment_tissue_artifact_removal_empty_mask_fallback` | All-zeros result → pre-removal mask used |
| `TestGrandQCArtifactRemoverCore.*` (10 tests) | Class exclusion logic, shape preservation, MPP rescaling |