### PR TITLE
chore: bump version to v1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mussel"
-version = "1.4.1"
+version = "1.4.2"
 description = "weakly supervised computational pathology on whole slide images"
 license = { text = "GPL-3.0 license" }
 readme = "README.md"


### PR DESCRIPTION
Patch release for bug fixes since v1.4.1:

- `65fc2eb` fix: use `.patch_features.h5` for slide model intermediate output (avoids filename collision with tessellation input in batch mode)
- `9c5a29d` fix: use `_numpy_to_torch` for bfloat16-aware H5 feature loading in `_main_batch`
- `7f52762` fix: add missing `_numpy_to_torch` import; add batch-mode bfloat16/float16 precision regression tests

After merge, tag `v1.4.2` on main.