### PR TITLE
chore: rename PyPI package to mussel-pathology

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mussel"
+name = "mussel-pathology"
 version = "1.4.3"
 description = "weakly supervised computational pathology on whole slide images"
 license = { text = "GPL-3.0 license" }


### PR DESCRIPTION
The `mussel` name on PyPI is owned by another project. Renaming the distribution package to `mussel-pathology`.

- Install: `pip install mussel-pathology`
- Import name unchanged: `import mussel`
- CLI commands unchanged