### PR TITLE
ci: publish to PyPI on version tags via OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,28 @@ jobs:
           -m "not slow and not integration and not requires_tensorflow and not requires_fastattn" \
           --tb=short \
           -v
+
+  publish:
+    name: Build and publish to PyPI
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mussel-pathology/
+
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Build distribution
+      run: uv run --with build python -m build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a `publish` job to CI that fires on `v*` tags.

## How it works
1. Runs only after `test` job passes
2. Triggers on `refs/tags/v*` (i.e. `git tag v1.4.4 && git push origin v1.4.4`)
3. Builds `sdist` + `wheel` with `python -m build`
4. Uploads via [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) using **OIDC trusted publishing** — no API token stored in secrets

## One-time setup required
Add a trusted publisher on PyPI at:
https://pypi.org/manage/project/mussel-pathology/settings/publishing/

Settings:
- **Owner**: `pathology-data-mining`
- **Repository**: `Mussel`
- **Workflow**: `ci.yml`
- **Environment**: `pypi`

Then create a `pypi` environment in GitHub repo settings (Settings → Environments).