### PR TITLE
docs: add mussel-nf Nextflow pipeline reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Changes
+
+<!-- Bullet list of key changes -->
+-
+
+## Testing
+
+<!-- How was this tested? Unit tests added/run? Manual verification? -->
+- [ ] Tests added / updated
+- [ ] `uv run pytest tests` passes
+
+## Notes
+
+<!-- Anything reviewers should know (breaking changes, follow-up work, etc.) -->

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ The tools currently available from Mussel are,
 These are described, with examples, in the accompanying document, [README-commands.md](README-commands.md)
 
 
+## Nextflow pipeline
+
+For running Mussel at scale on a compute cluster, see
+**[mussel-nf](https://github.com/pathology-data-mining/mussel-nf)** — a Nextflow
+pipeline that wraps the Mussel CLI tools and handles job scheduling, parallelism,
+and output management across large slide cohorts.
+
 ## License
 This code is made available under the GPLv3 License and is available for non-commercial academic purposes.
 Forked from CLAM, © [Mahmood Lab](http://www.mahmoodlab.org).


### PR DESCRIPTION
Adds a short **Nextflow pipeline** section to README.md linking to [mussel-nf](https://github.com/pathology-data-mining/mussel-nf).