### PR TITLE
fix: exit non-zero when all slides fail in aggregate_slide_features_batch

### DIFF
--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -311,6 +311,18 @@ def _main_batch(cfg: ExtractFeaturesConfig):
             gpu_device_ids=cfg.gpu_device_ids,
             slide_batch_size=cfg.slide_batch_size,
         )
+
+        # Defense-in-depth: verify at least one output file was created.
+        # aggregate_slide_features_batch already raises when ALL slides fail,
+        # but guard here too in case of unexpected silent failures.
+        missing = [p for p in output_pt_paths if not os.path.isfile(p)]
+        if len(missing) == len(output_pt_paths):
+            raise RuntimeError(
+                f"extract_features produced no output files: all {len(output_pt_paths)} "
+                ".features.pt files are missing after slide-level aggregation. "
+                "All slides may have failed (e.g. CUDA out of memory in TITAN). "
+                "Check logs above for per-slide errors."
+            )
     else:
         # Single-step: extract directly to final output (no aggregation)
         extract_patch_features_batch(

--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -316,7 +316,7 @@ def _main_batch(cfg: ExtractFeaturesConfig):
         # aggregate_slide_features_batch already raises when ALL slides fail,
         # but guard here too in case of unexpected silent failures.
         missing = [p for p in output_pt_paths if not os.path.isfile(p)]
-        if len(missing) == len(output_pt_paths):
+        if output_pt_paths and len(missing) == len(output_pt_paths):
             raise RuntimeError(
                 f"extract_features produced no output files: all {len(output_pt_paths)} "
                 ".features.pt files are missing after slide-level aggregation. "

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1685,7 +1685,7 @@ def aggregate_slide_features_batch(
     else:
         logger.info(f"\n=== All {num_slides} slides processed successfully ===")
 
-    if len(failed_slides) == num_slides:
+    if failed_slides and len(failed_slides) == num_slides:
         raise RuntimeError(
             f"All {num_slides} slide(s) failed during 'model' aggregation "
             f"(model={model_type}). Failed: {', '.join(failed_slides)}. "

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1451,11 +1451,15 @@ def aggregate_slide_features_batch(
 
         if failed_slides:
             logger.warning(f"\n=== Batch Processing Summary ===")
-            logger.warning(
-                f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-            )
+            logger.warning(f"Successfully processed: {len(successful_slides)}/{num_slides} slides")
             logger.warning(f"Failed: {len(failed_slides)} slides")
             logger.warning(f"Failed slides: {', '.join(failed_slides)}")
+            if len(failed_slides) == num_slides:
+                raise RuntimeError(
+                    f"All {num_slides} slide(s) failed during {aggregation_method!r} aggregation. "
+                    f"Failed: {', '.join(failed_slides)}. "
+                    "Check logs above for per-slide errors."
+                )
         else:
             logger.info(f"\n=== All {num_slides} slides processed successfully ===")
 
@@ -1676,13 +1680,17 @@ def aggregate_slide_features_batch(
 
     if failed_slides:
         logger.warning(f"\n=== Batch Processing Summary ===")
-        logger.warning(
-            f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-        )
         logger.warning(f"Failed: {len(failed_slides)} slides")
         logger.warning(f"Failed slides: {', '.join(failed_slides)}")
     else:
         logger.info(f"\n=== All {num_slides} slides processed successfully ===")
+
+    if len(failed_slides) == num_slides:
+        raise RuntimeError(
+            f"All {num_slides} slide(s) failed during 'model' aggregation "
+            f"(model={model_type}). Failed: {', '.join(failed_slides)}. "
+            "Check logs above for per-slide errors (e.g. CUDA out of memory)."
+        )
 
     logger.info(f"Batch aggregation complete")
     return output_h5_paths, output_pt_paths


### PR DESCRIPTION
## Summary

Fixes a silent failure mode where `extract_features` (and TITAN in particular) would exit with code 0 even when all slides failed during batch aggregation.

## Changes

- **`mussel/utils/feature_extract.py`**: Raise `RuntimeError` in `aggregate_slide_features_batch` when **all** slides fail (both the method-level and model-level aggregation paths).
- **`mussel/cli/extract_features.py`**: Add a defense-in-depth check after `aggregate_slide_features_batch` returns — raise `RuntimeError` if no output `.features.pt` files were created.

## Motivation

When TITAN (or other models) hits a CUDA OOM or similar error on every slide, the batch loop catches per-slide exceptions, logs warnings, and continues — returning without writing any outputs but still exiting 0. This silently breaks downstream pipelines that depend on the exit code.

## Testing

- Verified the new `RuntimeError` is raised when the failed-slides count equals total slides.
- Existing partial-failure behavior (some slides succeed, some fail) is unchanged — a warning is logged but no exception is raised.