### PR TITLE
Fix: exit non-zero when all slides fail in aggregate_slide_features_batch

### DIFF
--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -311,6 +311,18 @@ def _main_batch(cfg: ExtractFeaturesConfig):
             gpu_device_ids=cfg.gpu_device_ids,
             slide_batch_size=cfg.slide_batch_size,
         )
+
+        # Defense-in-depth: verify at least one output file was created.
+        # aggregate_slide_features_batch already raises when ALL slides fail,
+        # but guard here too in case of unexpected silent failures.
+        missing = [p for p in output_pt_paths if not os.path.isfile(p)]
+        if len(missing) == len(output_pt_paths):
+            raise RuntimeError(
+                f"extract_features produced no output files: all {len(output_pt_paths)} "
+                ".features.pt files are missing after slide-level aggregation. "
+                "All slides may have failed (e.g. CUDA out of memory in TITAN). "
+                "Check logs above for per-slide errors."
+            )
     else:
         # Single-step: extract directly to final output (no aggregation)
         extract_patch_features_batch(

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1451,11 +1451,15 @@ def aggregate_slide_features_batch(
 
         if failed_slides:
             logger.warning(f"\n=== Batch Processing Summary ===")
-            logger.warning(
-                f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-            )
+            logger.warning(f"Successfully processed: {len(successful_slides)}/{num_slides} slides")
             logger.warning(f"Failed: {len(failed_slides)} slides")
             logger.warning(f"Failed slides: {', '.join(failed_slides)}")
+            if len(failed_slides) == num_slides:
+                raise RuntimeError(
+                    f"All {num_slides} slide(s) failed during {aggregation_method!r} aggregation. "
+                    f"Failed: {', '.join(failed_slides)}. "
+                    "Check logs above for per-slide errors."
+                )
         else:
             logger.info(f"\n=== All {num_slides} slides processed successfully ===")
 
@@ -1676,13 +1680,17 @@ def aggregate_slide_features_batch(
 
     if failed_slides:
         logger.warning(f"\n=== Batch Processing Summary ===")
-        logger.warning(
-            f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-        )
         logger.warning(f"Failed: {len(failed_slides)} slides")
         logger.warning(f"Failed slides: {', '.join(failed_slides)}")
     else:
         logger.info(f"\n=== All {num_slides} slides processed successfully ===")
+
+    if len(failed_slides) == num_slides:
+        raise RuntimeError(
+            f"All {num_slides} slide(s) failed during 'model' aggregation "
+            f"(model={model_type}). Failed: {', '.join(failed_slides)}. "
+            "Check logs above for per-slide errors (e.g. CUDA out of memory)."
+        )
 
     logger.info(f"Batch aggregation complete")
     return output_h5_paths, output_pt_paths


### PR DESCRIPTION
## Summary

When TITAN slide aggregation fails for every slide in a batch (e.g. CUDA OOM), `extract_features` was silently exiting 0 with no output files. Nextflow showed confusing `exit:0 Failed Tasks` and spuriously retried tasks.

## Changes

1. `feature_extract.py aggregate_slide_features_batch`: raise `RuntimeError` when all slides fail (both model and non-model paths).
2. `extract_features.py _main_batch`: defense-in-depth — raise if all output `.pt` files are missing after aggregation.

With `errorStrategy='ignore'` in nextflow.config, exit:1 is cleanly ignored; WDS coverage check resets slides to PENDING.

## Testing
- 27 existing tests pass: `pytest tests/mussel/utils/test_feature_extract.py tests/mussel/cli/test_extract_features.py`
- 458 total suite tests pass, 0 failures