### PR TITLE
[codex] add batch mode to tessellate CLI

### DIFF
--- a/README-commands.md
+++ b/README-commands.md
@@ -49,6 +49,22 @@ tessellate \
     num_workers=1
 ```
 
+Batch mode groups multiple slides into one `tessellate` invocation and writes one patch
+HDF5 per slide. This is intended for workflow engines where many short per-slide jobs
+create scheduler overhead:
+
+```bash
+tessellate \
+    'slide_paths=[slide_a.svs,slide_b.svs]' \
+    'slide_ids=[slide_a,slide_b]' \
+    output_dir=tiles \
+    seg_config=biopsy
+```
+
+Use `output_h5_paths=[a.patch.h5,b.patch.h5]` instead of `output_dir` for explicit
+per-slide destinations. Batch mode writes patch H5 outputs only; thumbnail, mask,
+grid-mask, and tile PNG outputs are supported only in single-slide mode.
+
 #### Supported slide formats
 
 Mussel uses [tiffslide](https://github.com/Bayer-Group/tiffslide)
@@ -520,5 +536,4 @@ Each input file `<stem>.<ext>` produces `output_dir/<stem>.tiff`. Pass
 | `downscale_by` | `1` | Integer downsample factor (e.g. `2` converts a 40× slide to 20×). |
 | `num_workers` | `1` | Parallel workers for batch mode (`0` = all CPUs). |
 | `bigtiff` | `false` | Write BigTIFF format (required for files > ~4 GB). |
-
 

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -436,6 +436,17 @@ def _resolve_batch_outputs(cfg: TessellateConfig) -> list[tuple[str, str, str]]:
             str(output_dir / f"{slide_id}.patch.h5") for slide_id in slide_ids
         ]
 
+    duplicate_outputs = sorted(
+        output_path
+        for output_path in set(output_h5_paths)
+        if output_h5_paths.count(output_path) > 1
+    )
+    if duplicate_outputs:
+        raise ValueError(
+            "Batch mode output paths must be unique; duplicate output_h5_path(s): "
+            + ", ".join(duplicate_outputs)
+        )
+
     return list(zip(slide_paths, slide_ids, output_h5_paths))
 
 
@@ -490,7 +501,8 @@ def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
             for slide_id, slide_path, output_h5_path, error in failures:
                 f.write(f"{slide_id}\t{slide_path}\t{output_h5_path}\t{error}\n")
 
-    if failures and not cfg.continue_on_error:
+    all_slides_failed = failures and len(failures) == len(items)
+    if failures and (not cfg.continue_on_error or all_slides_failed):
         raise RuntimeError(
             f"Tessellation failed for {len(failures)} of {len(items)} slide(s)."
         )
@@ -507,6 +519,10 @@ def main(
     """Tile a whole slide image and perform tissue segmentation."""
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
     if cfg.slide_paths is not None:
+        if cfg.slide_path is not None or cfg.output_h5_path is not None:
+            raise ValueError(
+                "Batch mode is mutually exclusive with slide_path and output_h5_path."
+            )
         _run_batch(cfg, seg_cfg)
         return
 

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -382,10 +382,13 @@ def _run_tessellation(
     seg_cfg: dict,
     artifact_remover_fn: "Optional[GrandQCArtifactRemover]",
     slide_id: Optional[str] = None,
+    neural_segmenter: Optional[Any] = None,
 ) -> tuple[Any, Any, np.ndarray] | None:
     # Strip config-only keys that are not segment_tissue() parameters.
     call_seg_cfg = dict(seg_cfg)
     call_seg_cfg.pop("artifact_exclude_classes", None)
+    if neural_segmenter is not None:
+        call_seg_cfg["neural_segmenter"] = neural_segmenter
     values = segment_tissue(
         slide_path=slide_path,
         slide_id=slide_id,
@@ -450,6 +453,16 @@ def _resolve_batch_outputs(cfg: TessellateConfig) -> list[tuple[str, str, str]]:
     return list(zip(slide_paths, slide_ids, output_h5_paths))
 
 
+def _build_neural_segmenter(seg_cfg: dict) -> Optional[Any]:
+    if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
+        return None
+
+    from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+    logger.info("Loading neural tissue segmenter once for tessellate batch mode.")
+    return NeuralTissueSegmenter()
+
+
 def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
     if any(
         value is not None
@@ -466,6 +479,7 @@ def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
         )
 
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    neural_segmenter = _build_neural_segmenter(seg_cfg)
     failures: list[tuple[str, str, str, str]] = []
     items = _resolve_batch_outputs(cfg)
     logger.info("Batch tessellating %d slide(s)", len(items))
@@ -480,6 +494,7 @@ def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
                 output_h5_path=output_h5_path,
                 seg_cfg=seg_cfg,
                 artifact_remover_fn=artifact_remover_fn,
+                neural_segmenter=neural_segmenter,
             )
             if result is None or not Path(output_h5_path).exists():
                 raise RuntimeError(f"tessellation produced no patch H5 for {slide_id}")

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -453,14 +453,40 @@ def _resolve_batch_outputs(cfg: TessellateConfig) -> list[tuple[str, str, str]]:
     return list(zip(slide_paths, slide_ids, output_h5_paths))
 
 
-def _build_neural_segmenter(seg_cfg: dict) -> Optional[Any]:
+def _build_neural_segmenter(
+    seg_cfg: dict,
+    use_gpu: Optional[bool] = None,
+    gpu_device_id: Optional[int | List[int]] = None,
+    gpu_device_ids: Optional[List[int]] = None,
+) -> Optional[Any]:
     if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
         return None
 
     from mussel.utils.neural_seg import NeuralTissueSegmenter
 
-    logger.info("Loading neural tissue segmenter once for tessellate batch mode.")
-    return NeuralTissueSegmenter()
+    if use_gpu is None:
+        logger.info("Loading neural tissue segmenter.")
+        return NeuralTissueSegmenter()
+
+    if not use_gpu:
+        return NeuralTissueSegmenter(device="cpu")
+
+    import torch
+
+    from mussel.utils.gpu import first_gpu_device_id, resolve_gpu_device_id
+
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "seg_config.seg_model='neural' requested with use_gpu=True, "
+            "but CUDA is not available. Set use_gpu=False to run neural "
+            "segmentation on CPU."
+        )
+    device_id = first_gpu_device_id(
+        resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
+    )
+    device = "cuda" if device_id is None else f"cuda:{device_id}"
+    logger.info("Loading neural tissue segmenter.")
+    return NeuralTissueSegmenter(device=device)
 
 
 def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -21,8 +21,7 @@ from mussel.utils.artifact_removal import (
     EXCLUDE_PENMARKS_ONLY,
     GrandQCArtifactRemover,
 )
-from mussel.utils.segment import (draw_slide_mask, save_patches_png,
-                                  segment_tissue)
+from mussel.utils.segment import draw_slide_mask, save_patches_png, segment_tissue
 
 
 @dataclass
@@ -111,9 +110,7 @@ class SegConfig:
     remove_penmarks: bool = (
         False  # If True, apply pen mark removal to the tissue mask before patching.
     )
-    artifact_exclude_classes: Optional[List[int]] = field(
-        default=None
-    )
+    artifact_exclude_classes: Optional[List[int]] = field(default=None)
     # Optional list of GrandQC class indices to exclude (overrides remove_artifacts /
     # remove_penmarks preset logic when set).  Use the CLASS_* constants from
     # mussel.utils.artifact_removal, e.g. [4, 7] for pen marks + background only.
@@ -240,6 +237,20 @@ class TessellateConfig:
     slide_id (Optional[str]): Identifier written into the HDF5 output. Defaults to the slide
         filename without extension.
     output_h5_path (str): Path for the HDF5 output file containing tile coordinates and metadata.
+    slide_paths (Optional[List[str]]): Batch mode input slide paths. Mutually exclusive with
+        ``slide_path``.
+    slide_ids (Optional[List[str]]): Optional batch mode slide IDs. Defaults to each slide
+        filename without extension.
+    output_h5_paths (Optional[List[str]]): Batch mode output HDF5 paths. Mutually exclusive with
+        ``output_dir``.
+    output_dir (Optional[str]): Batch mode output directory. When set, writes
+        ``{slide_id}.patch.h5`` for each input slide.
+    continue_on_error (bool): In batch mode, continue processing remaining slides after a
+        per-slide failure and exit successfully after writing a failures TSV if
+        ``failures_tsv_path`` is set. By default any failure causes a non-zero exit after the
+        first failed slide.
+    failures_tsv_path (Optional[str]): Optional TSV path receiving ``slide_id, slide_path,
+        output_h5_path, error`` rows for batch failures.
     output_png_dir (Optional[str]): Directory to save each tile as an individual PNG file.
         Filtered by ``png_config`` settings when set.
     output_mask_path (Optional[str]): Path to save a PNG overlay showing the segmented tissue
@@ -255,9 +266,15 @@ class TessellateConfig:
     """
 
     defaults: List[Any] = field(default_factory=lambda: defaults)
-    slide_path: str = MISSING
+    slide_path: Optional[str] = None
     slide_id: Optional[str] = None
-    output_h5_path: str = MISSING
+    output_h5_path: Optional[str] = None
+    slide_paths: Optional[List[str]] = None
+    slide_ids: Optional[List[str]] = None
+    output_h5_paths: Optional[List[str]] = None
+    output_dir: Optional[str] = None
+    continue_on_error: bool = False
+    failures_tsv_path: Optional[str] = None
     output_png_dir: Optional[str] = None
     output_mask_path: Optional[str] = None
     output_grid_mask_path: Optional[str] = None
@@ -278,6 +295,7 @@ extract_features and tessellate_extract_features.
 Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
   slide_path          Path to the slide file (required)
   output_h5_path      Path for the output HDF5 file (required)
+  slide_paths         Batch mode slide paths; use output_h5_paths or output_dir for outputs
   seg_config          Preset segmentation profile: default | biopsy | resection | tcga
   seg_config.mpp      Target resolution in µm/px (default 0.5 ≈ 20×; 0.25 ≈ 40×)
   seg_config.patch_size  Tile size in pixels at the target MPP (default 256)
@@ -285,6 +303,7 @@ Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
 
 Example:
   tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=biopsy
+  tessellate 'slide_paths=[a.svs,b.svs]' output_dir=tiles seg_config=biopsy
 """
 
 parameter_doc = f"""
@@ -352,23 +371,157 @@ def _build_artifact_remover(
     return remover
 
 
+def _slide_id_for_path(slide_path: str, slide_id: Optional[str] = None) -> str:
+    return slide_id if slide_id else Path(slide_path).stem
+
+
+def _run_tessellation(
+    *,
+    slide_path: str,
+    output_h5_path: str,
+    seg_cfg: dict,
+    artifact_remover_fn: "Optional[GrandQCArtifactRemover]",
+    slide_id: Optional[str] = None,
+) -> tuple[Any, Any, np.ndarray] | None:
+    # Strip config-only keys that are not segment_tissue() parameters.
+    call_seg_cfg = dict(seg_cfg)
+    call_seg_cfg.pop("artifact_exclude_classes", None)
+    values = segment_tissue(
+        slide_path=slide_path,
+        slide_id=slide_id,
+        output_h5_path=output_h5_path,
+        artifact_remover_fn=artifact_remover_fn,
+        **call_seg_cfg,
+    )
+    if not values:
+        return None
+    polygon, grid, coords, _ = values
+    return polygon, grid, coords
+
+
+def _resolve_batch_outputs(cfg: TessellateConfig) -> list[tuple[str, str, str]]:
+    slide_paths = list(cfg.slide_paths or [])
+    if not slide_paths:
+        raise ValueError(
+            "Batch mode requires slide_paths to contain at least one slide."
+        )
+
+    slide_ids = (
+        list(cfg.slide_ids)
+        if cfg.slide_ids is not None
+        else [_slide_id_for_path(p) for p in slide_paths]
+    )
+    if len(slide_ids) != len(slide_paths):
+        raise ValueError(
+            f"slide_ids length ({len(slide_ids)}) must match slide_paths length ({len(slide_paths)})."
+        )
+
+    has_output_h5_paths = cfg.output_h5_paths is not None
+    has_output_dir = cfg.output_dir is not None
+    if has_output_h5_paths == has_output_dir:
+        raise ValueError(
+            "Batch mode requires exactly one of output_h5_paths or output_dir."
+        )
+
+    if has_output_h5_paths:
+        output_h5_paths = list(cfg.output_h5_paths or [])
+        if len(output_h5_paths) != len(slide_paths):
+            raise ValueError(
+                "output_h5_paths length "
+                f"({len(output_h5_paths)}) must match slide_paths length ({len(slide_paths)})."
+            )
+    else:
+        output_dir = Path(cfg.output_dir)
+        output_h5_paths = [
+            str(output_dir / f"{slide_id}.patch.h5") for slide_id in slide_ids
+        ]
+
+    return list(zip(slide_paths, slide_ids, output_h5_paths))
+
+
+def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
+    if any(
+        value is not None
+        for value in (
+            cfg.output_png_dir,
+            cfg.output_mask_path,
+            cfg.output_grid_mask_path,
+            cfg.output_thumbnail_path,
+        )
+    ):
+        raise ValueError(
+            "Batch tessellate mode only writes patch H5 outputs; PNG, mask, grid-mask, "
+            "and thumbnail outputs are not supported."
+        )
+
+    artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    failures: list[tuple[str, str, str, str]] = []
+    items = _resolve_batch_outputs(cfg)
+    logger.info("Batch tessellating %d slide(s)", len(items))
+
+    for i, (slide_path, slide_id, output_h5_path) in enumerate(items, start=1):
+        try:
+            Path(output_h5_path).parent.mkdir(parents=True, exist_ok=True)
+            logger.info("Tessellating slide %d/%d: %s", i, len(items), slide_id)
+            result = _run_tessellation(
+                slide_path=slide_path,
+                slide_id=slide_id,
+                output_h5_path=output_h5_path,
+                seg_cfg=seg_cfg,
+                artifact_remover_fn=artifact_remover_fn,
+            )
+            if result is None or not Path(output_h5_path).exists():
+                raise RuntimeError(f"tessellation produced no patch H5 for {slide_id}")
+        except Exception as exc:
+            failures.append((slide_id, slide_path, output_h5_path, str(exc)))
+            try:
+                Path(output_h5_path).unlink(missing_ok=True)
+            except Exception:
+                pass
+            logger.exception("Failed to tessellate %s", slide_id)
+            if not cfg.continue_on_error:
+                break
+
+    if failures and cfg.failures_tsv_path:
+        failure_path = Path(cfg.failures_tsv_path)
+        failure_path.parent.mkdir(parents=True, exist_ok=True)
+        with failure_path.open("w") as f:
+            f.write("slide_id\tslide_path\toutput_h5_path\terror\n")
+            for slide_id, slide_path, output_h5_path, error in failures:
+                f.write(f"{slide_id}\t{slide_path}\t{output_h5_path}\t{error}\n")
+
+    if failures and not cfg.continue_on_error:
+        raise RuntimeError(
+            f"Tessellation failed for {len(failures)} of {len(items)} slide(s)."
+        )
+    if failures:
+        logger.warning(
+            "Tessellation failed for %d of %d slide(s).", len(failures), len(items)
+        )
+
+
 @hydra.main(version_base=None, config_path=".", config_name="tessellate_config")
 def main(
     cfg: TessellateConfig,
 ):
     """Tile a whole slide image and perform tissue segmentation."""
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    if cfg.slide_paths is not None:
+        _run_batch(cfg, seg_cfg)
+        return
+
+    if cfg.slide_path is None or cfg.output_h5_path is None:
+        raise ValueError("Single-slide mode requires slide_path and output_h5_path.")
+
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
-    # Strip config-only keys that are not segment_tissue() parameters.
-    seg_cfg.pop("artifact_exclude_classes", None)
-    if values := segment_tissue(
+    if values := _run_tessellation(
         slide_path=cfg.slide_path,
         slide_id=cfg.slide_id,
         output_h5_path=cfg.output_h5_path,
+        seg_cfg=seg_cfg,
         artifact_remover_fn=artifact_remover_fn,
-        **seg_cfg,
     ):
-        polygon, grid, coords, _ = values
+        polygon, grid, coords = values
     else:
         return
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 
 import h5py
 import hydra
-import torch
 from hydra.conf import HelpConf, HydraConf
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
@@ -28,6 +27,7 @@ from mussel.cli.tessellate import (
     TcgaSegConfig,
     VisConfig,
     _build_artifact_remover,
+    _build_neural_segmenter,
 )
 from mussel.cli.tessellate_extract_features_common import (
     create_visualizations,
@@ -58,39 +58,11 @@ from mussel.utils.artifact_removal import (
 )
 from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
-from mussel.utils.gpu import first_gpu_device_id, resolve_gpu_device_id
 
 # isort: on
 
 # Private aliases used throughout this module
 _is_remote_path = is_remote_path
-
-
-def _build_neural_segmenter(
-    seg_cfg,
-    use_gpu: bool,
-    gpu_device_id: Optional[int | List[int]] = None,
-    gpu_device_ids: Optional[List[int]] = None,
-):
-    if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
-        return None
-
-    from mussel.utils.neural_seg import NeuralTissueSegmenter
-
-    if not use_gpu:
-        return NeuralTissueSegmenter(device="cpu")
-    if not torch.cuda.is_available():
-        raise RuntimeError(
-            "seg_config.seg_model='neural' requested with use_gpu=True, "
-            "but CUDA is not available. Set use_gpu=False to run neural "
-            "segmentation on CPU."
-        )
-    device_id = first_gpu_device_id(
-        resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
-    )
-
-    device = "cuda" if device_id is None else f"cuda:{device_id}"
-    return NeuralTissueSegmenter(device=device)
 
 
 def _build_segmentation_runtime(cfg: "TessellateExtractFeaturesConfig"):

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -1,7 +1,10 @@
 import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import h5py
 import numpy as np
+import pytest
 from omegaconf import OmegaConf
 
 import mussel.cli.tessellate
@@ -58,6 +61,118 @@ def test_tessellate(tmp_path, num_workers):
         assert np.all(
             coords[:, 1] + patch_size <= _SLIDE_HEIGHT
         ), "y + patch_size exceeds slide height"
+
+
+def test_tessellate_batch_writes_patch_h5_outputs(tmp_path):
+    slide_paths = ["slide_a.svs", "slide_b.svs"]
+    output_dir = tmp_path / "tiles"
+    seg_config = SegConfig(segment_threshold=0)
+    cfg = TessellateConfig(
+        slide_paths=slide_paths,
+        slide_ids=["A", "B"],
+        output_dir=str(output_dir),
+        seg_config=seg_config,
+    )
+
+    def fake_segment_tissue(*, output_h5_path, **kwargs):
+        Path(output_h5_path).write_text("patch h5")
+        return MagicMock(), MagicMock(), np.array([[0, 0]]), None
+
+    with patch(
+        "mussel.cli.tessellate.segment_tissue", side_effect=fake_segment_tissue
+    ) as mock_segment:
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    assert mock_segment.call_count == 2
+    assert (output_dir / "A.patch.h5").exists()
+    assert (output_dir / "B.patch.h5").exists()
+
+
+def test_tessellate_batch_can_use_explicit_output_h5_paths(tmp_path):
+    out_a = tmp_path / "custom_a.h5"
+    out_b = tmp_path / "custom_b.h5"
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        output_h5_paths=[str(out_a), str(out_b)],
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    def fake_segment_tissue(*, output_h5_path, **kwargs):
+        Path(output_h5_path).write_text("patch h5")
+        return MagicMock(), MagicMock(), np.array([[0, 0]]), None
+
+    with patch("mussel.cli.tessellate.segment_tissue", side_effect=fake_segment_tissue):
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    assert out_a.exists()
+    assert out_b.exists()
+
+
+def test_tessellate_batch_fails_on_first_slide_failure(tmp_path):
+    output_dir = tmp_path / "tiles"
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        slide_ids=["A", "B"],
+        output_dir=str(output_dir),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    def fake_segment_tissue(*, output_h5_path, **kwargs):
+        if output_h5_path.endswith("A.patch.h5"):
+            raise RuntimeError("boom")
+        Path(output_h5_path).write_text("patch h5")
+        return MagicMock(), MagicMock(), np.array([[0, 0]]), None
+
+    with patch(
+        "mussel.cli.tessellate.segment_tissue", side_effect=fake_segment_tissue
+    ) as mock_segment:
+        with pytest.raises(RuntimeError, match="1 of 2"):
+            mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    assert mock_segment.call_count == 1
+    assert not (output_dir / "A.patch.h5").exists()
+    assert not (output_dir / "B.patch.h5").exists()
+
+
+def test_tessellate_batch_continue_on_error_writes_failures_tsv(tmp_path):
+    output_dir = tmp_path / "tiles"
+    failures_tsv = tmp_path / "failures.tsv"
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        slide_ids=["A", "B"],
+        output_dir=str(output_dir),
+        continue_on_error=True,
+        failures_tsv_path=str(failures_tsv),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    def fake_segment_tissue(*, output_h5_path, **kwargs):
+        if output_h5_path.endswith("A.patch.h5"):
+            raise RuntimeError("boom")
+        Path(output_h5_path).write_text("patch h5")
+        return MagicMock(), MagicMock(), np.array([[0, 0]]), None
+
+    with patch(
+        "mussel.cli.tessellate.segment_tissue", side_effect=fake_segment_tissue
+    ) as mock_segment:
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    assert mock_segment.call_count == 2
+    assert not (output_dir / "A.patch.h5").exists()
+    assert (output_dir / "B.patch.h5").exists()
+    assert "A\tslide_a.svs" in failures_tsv.read_text()
+
+
+def test_tessellate_batch_rejects_optional_visual_outputs(tmp_path):
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs"],
+        output_dir=str(tmp_path),
+        output_thumbnail_path=str(tmp_path / "thumb.png"),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    with pytest.raises(ValueError, match="only writes patch H5"):
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
 
 
 def test_seg_config_new_fields_defaults():

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -108,6 +108,37 @@ def test_tessellate_batch_can_use_explicit_output_h5_paths(tmp_path):
     assert out_b.exists()
 
 
+def test_tessellate_batch_reuses_neural_segmenter(tmp_path):
+    output_dir = tmp_path / "tiles"
+    shared_segmenter = MagicMock()
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        slide_ids=["A", "B"],
+        output_dir=str(output_dir),
+        seg_config=SegConfig(seg_model="neural"),
+    )
+
+    def fake_segment_tissue(*, output_h5_path, **kwargs):
+        Path(output_h5_path).write_text("patch h5")
+        return MagicMock(), MagicMock(), np.array([[0, 0]]), None
+
+    with patch(
+        "mussel.utils.neural_seg.NeuralTissueSegmenter",
+        return_value=shared_segmenter,
+    ) as mock_segmenter_cls:
+        with patch(
+            "mussel.cli.tessellate.segment_tissue", side_effect=fake_segment_tissue
+        ) as mock_segment:
+            mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    mock_segmenter_cls.assert_called_once_with()
+    assert mock_segment.call_count == 2
+    assert all(
+        call.kwargs["neural_segmenter"] is shared_segmenter
+        for call in mock_segment.call_args_list
+    )
+
+
 def test_tessellate_batch_fails_on_first_slide_failure(tmp_path):
     output_dir = tmp_path / "tiles"
     cfg = TessellateConfig(

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -163,6 +163,64 @@ def test_tessellate_batch_continue_on_error_writes_failures_tsv(tmp_path):
     assert "A\tslide_a.svs" in failures_tsv.read_text()
 
 
+def test_tessellate_batch_continue_on_error_fails_when_all_slides_fail(tmp_path):
+    output_dir = tmp_path / "tiles"
+    failures_tsv = tmp_path / "failures.tsv"
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        slide_ids=["A", "B"],
+        output_dir=str(output_dir),
+        continue_on_error=True,
+        failures_tsv_path=str(failures_tsv),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    with patch(
+        "mussel.cli.tessellate.segment_tissue", side_effect=RuntimeError("boom")
+    ) as mock_segment:
+        with pytest.raises(RuntimeError, match="2 of 2"):
+            mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+    assert mock_segment.call_count == 2
+    assert failures_tsv.exists()
+
+
+def test_tessellate_batch_rejects_duplicate_output_h5_paths(tmp_path):
+    duplicate_path = str(tmp_path / "duplicate.patch.h5")
+    cfg = TessellateConfig(
+        slide_paths=["slide_a.svs", "slide_b.svs"],
+        output_h5_paths=[duplicate_path, duplicate_path],
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    with pytest.raises(ValueError, match="must be unique"):
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+
+def test_tessellate_batch_rejects_duplicate_output_dir_slide_ids(tmp_path):
+    cfg = TessellateConfig(
+        slide_paths=["/a/slide.svs", "/b/slide.svs"],
+        output_dir=str(tmp_path),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    with pytest.raises(ValueError, match="must be unique"):
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+
+def test_tessellate_batch_rejects_single_slide_options(tmp_path):
+    cfg = TessellateConfig(
+        slide_path="single.svs",
+        output_h5_path=str(tmp_path / "single.patch.h5"),
+        slide_paths=["slide_a.svs"],
+        output_dir=str(tmp_path),
+        seg_config=SegConfig(segment_threshold=0),
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        mussel.cli.tessellate.main(OmegaConf.create(cfg))
+
+
 def test_tessellate_batch_rejects_optional_visual_outputs(tmp_path):
     cfg = TessellateConfig(
         slide_paths=["slide_a.svs"],


### PR DESCRIPTION
## Summary

Adds a batch-aware mode to the `tessellate` CLI so workflow engines can process multiple slides in one invocation while still writing one patch H5 per slide.

## Behavior

- Single-slide mode remains unchanged: `slide_path` + `output_h5_path`.
- Batch mode uses `slide_paths=[...]` plus either `output_h5_paths=[...]` or `output_dir=...`.
- Batch mode writes patch H5 outputs only and rejects optional PNG, mask, grid-mask, and thumbnail outputs.
- Default batch behavior is fail-fast and exits non-zero on the first slide failure.
- `continue_on_error=true` processes remaining slides, removes partial failed outputs, writes `failures_tsv_path` when provided, and exits successfully for partial-success workflow handling.

## Validation

- `python -m pytest -q tests/mussel/cli/test_tessellate.py` -> `17 passed`
- `python -m black --check mussel/cli/tessellate.py tests/mussel/cli/test_tessellate.py` reported both files unchanged; in this GPFS session the process only returned after the explicit timeout, but the formatter output was clean.
