### PR TITLE
[codex] fix tessellate neural segmentation

### DIFF
--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -19,25 +19,38 @@ from hydra.conf import HelpConf, HydraConf
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
-from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
-                                   ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig,
-                                   _build_artifact_remover)
+# isort: off
+from mussel.cli.tessellate import (
+    BiopsySegConfig,
+    PngConfig,
+    ResectionSegConfig,
+    SegConfig,
+    TcgaSegConfig,
+    VisConfig,
+    _build_artifact_remover,
+)
 from mussel.cli.tessellate_extract_features_common import (
-    create_visualizations, process_slide_tessellation_and_filtering,
-    process_slide_tessellation_only)
-from mussel.models import (ModelType, get_default_patch_size,
-                           get_required_patch_encoder)
-from mussel.utils import (aggregate_slide_features_batch,
-                          ensure_directory_exists,
-                          extract_patch_features_batch,
-                          get_batch_size_for_model,
-                          get_classifier_pkl_from_model_dir,
-                          get_model_path_from_dir, get_slide_id_from_path,
-                          get_slide_ids_from_paths, is_remote_path,
-                          resolve_aggregation_method, resolve_patch_encoder,
-                          resolve_remote_paths, safe_path_join,
-                          save_torch_tensor)
+    create_visualizations,
+    process_slide_tessellation_and_filtering,
+    process_slide_tessellation_only,
+)
+from mussel.models import ModelType, get_default_patch_size, get_required_patch_encoder
+from mussel.utils import (
+    aggregate_slide_features_batch,
+    ensure_directory_exists,
+    extract_patch_features_batch,
+    get_batch_size_for_model,
+    get_classifier_pkl_from_model_dir,
+    get_model_path_from_dir,
+    get_slide_id_from_path,
+    get_slide_ids_from_paths,
+    is_remote_path,
+    resolve_aggregation_method,
+    resolve_patch_encoder,
+    resolve_remote_paths,
+    safe_path_join,
+    save_torch_tensor,
+)
 from mussel.utils.artifact_removal import (
     EXCLUDE_ALL_ARTIFACTS,
     EXCLUDE_PENMARKS_ONLY,
@@ -46,8 +59,40 @@ from mussel.utils.artifact_removal import (
 from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
 
+# isort: on
+
 # Private aliases used throughout this module
 _is_remote_path = is_remote_path
+
+
+def _build_neural_segmenter(
+    seg_cfg,
+    use_gpu: bool,
+    gpu_device_id: Optional[int | List[int]] = None,
+    gpu_device_ids: Optional[List[int]] = None,
+):
+    if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
+        return None
+
+    from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+    if not use_gpu:
+        return NeuralTissueSegmenter(device="cpu")
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "seg_config.seg_model='neural' requested with use_gpu=True, "
+            "but CUDA is not available. Set use_gpu=False to run neural "
+            "segmentation on CPU."
+        )
+    if gpu_device_ids:
+        device_id = gpu_device_ids[0]
+    elif isinstance(gpu_device_id, list):
+        device_id = gpu_device_id[0] if gpu_device_id else None
+    else:
+        device_id = gpu_device_id
+
+    device = "cuda" if device_id is None else f"cuda:{device_id}"
+    return NeuralTissueSegmenter(device=device)
 
 
 def _resolve_precision(cfg: "TessellateExtractFeaturesConfig", model_type) -> str:
@@ -59,10 +104,16 @@ def _resolve_precision(cfg: "TessellateExtractFeaturesConfig", model_type) -> st
     ``ModelType.HOPTIMUS1``).
     """
     if model_type is not None and cfg.model_embedding_precision:
-        key = model_type.name.lower() if hasattr(model_type, "name") else str(model_type).lower()
+        key = (
+            model_type.name.lower()
+            if hasattr(model_type, "name")
+            else str(model_type).lower()
+        )
         if key in cfg.model_embedding_precision:
             return cfg.model_embedding_precision[key]
     return cfg.embedding_precision
+
+
 _safe_path_join = safe_path_join
 
 
@@ -174,7 +225,9 @@ class TessellateExtractFeaturesConfig:
     output_h5_suffix: str = "features.h5"
     output_pt_suffix: str = "features.pt"
     slide_batch_size: int = 8
-    max_slide_patches: Optional[int] = None  # Max patches per slide for slide-level models; large slides are subsampled
+    max_slide_patches: Optional[int] = (
+        None  # Max patches per slide for slide-level models; large slides are subsampled
+    )
     # Common parameters
     classifier_pkl: Optional[str] = None
     classifier_threshold: float = 0.75
@@ -214,8 +267,12 @@ class TessellateExtractFeaturesConfig:
     aggregation_method: str = "identity"
     slide_model_type: Any = None  # Can be ModelType or List[ModelType]
     ssl_verify: bool = True  # Whether to verify SSL certificates for remote operations
-    embedding_precision: str = "float32"  # Precision for saved embeddings: "float32", "float16", or "bfloat16"
-    model_embedding_precision: Any = None  # Per-model precision overrides: {model_name: precision}
+    embedding_precision: str = (
+        "float32"  # Precision for saved embeddings: "float32", "float16", or "bfloat16"
+    )
+    model_embedding_precision: Any = (
+        None  # Per-model precision overrides: {model_name: precision}
+    )
 
     def __post_init__(self):
         """Set default patch size based on model type if not explicitly set."""
@@ -570,7 +627,15 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
     )
     skip_second_extraction = use_filtering and models_are_same
 
-    artifact_remover_fn = _build_artifact_remover(OmegaConf.to_container(cfg.seg_config))
+    artifact_remover_fn = _build_artifact_remover(
+        OmegaConf.to_container(cfg.seg_config)
+    )
+    neural_segmenter = _build_neural_segmenter(
+        OmegaConf.to_container(cfg.seg_config),
+        cfg.use_gpu,
+        gpu_device_id=cfg.gpu_device_id,
+        gpu_device_ids=cfg.gpu_device_ids,
+    )
 
     # Process the slide using shared logic
     result = process_slide_tessellation_and_filtering(
@@ -591,6 +656,7 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
         two_step_mode=False,  # Single-slide mode doesn't use two-step
         slide_model_path=slide_model_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     )
 
     if result is None:
@@ -751,7 +817,15 @@ def _main_batch(
 
     # Instantiate artifact remover once per batch so model weights are loaded
     # only once rather than once per slide.
-    artifact_remover_fn = _build_artifact_remover(OmegaConf.to_container(cfg.seg_config))
+    artifact_remover_fn = _build_artifact_remover(
+        OmegaConf.to_container(cfg.seg_config)
+    )
+    neural_segmenter = _build_neural_segmenter(
+        OmegaConf.to_container(cfg.seg_config),
+        cfg.use_gpu,
+        gpu_device_id=cfg.gpu_device_id,
+        gpu_device_ids=cfg.gpu_device_ids,
+    )
 
     slide_results = []
     for i, (slide_path, slide_id) in enumerate(zip(cfg.slide_paths, slide_ids)):
@@ -778,6 +852,7 @@ def _main_batch(
                 skip_second_extraction=skip_second_extraction,
                 output_mask_path=output_mask_path,
                 artifact_remover_fn=artifact_remover_fn,
+                neural_segmenter=neural_segmenter,
             )
 
             if result is None:
@@ -981,8 +1056,12 @@ def _main_batch(
                 pt_dest = r["output_pt_path"]
                 with h5py.File(intermediate_h5_path, "r") as f:
                     raw = f["features"][:]
-                feature_dtype = _parse_feature_dtype(_resolve_precision(cfg, model_type))
-                features_arr = raw.astype(feature_dtype) if feature_dtype is not None else raw
+                feature_dtype = _parse_feature_dtype(
+                    _resolve_precision(cfg, model_type)
+                )
+                features_arr = (
+                    raw.astype(feature_dtype) if feature_dtype is not None else raw
+                )
                 features = _numpy_to_torch(features_arr)
                 save_torch_tensor(pt_dest, features, ssl_verify=cfg.ssl_verify)
                 logger.debug(f"Saved PT to {pt_dest}")
@@ -1124,8 +1203,12 @@ def _main_batch(
         for i, r in enumerate(slide_results):
             with h5py.File(temp_output_h5_paths[i], "r") as f:
                 raw = f["features"][:]
-                feature_dtype = _parse_feature_dtype(_resolve_precision(cfg, model_type))
-                features_arr = raw.astype(feature_dtype) if feature_dtype is not None else raw
+                feature_dtype = _parse_feature_dtype(
+                    _resolve_precision(cfg, model_type)
+                )
+                features_arr = (
+                    raw.astype(feature_dtype) if feature_dtype is not None else raw
+                )
                 features = _numpy_to_torch(features_arr)
                 save_torch_tensor(
                     r["output_pt_path"], features, ssl_verify=cfg.ssl_verify

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -58,6 +58,7 @@ from mussel.utils.artifact_removal import (
 )
 from mussel.utils.feature_extract import _numpy_to_torch, _parse_feature_dtype
 from mussel.utils.file import WSI_EXTENSIONS, collect_wsi_paths
+from mussel.utils.gpu import first_gpu_device_id, resolve_gpu_device_id
 
 # isort: on
 
@@ -84,15 +85,24 @@ def _build_neural_segmenter(
             "but CUDA is not available. Set use_gpu=False to run neural "
             "segmentation on CPU."
         )
-    if gpu_device_ids:
-        device_id = gpu_device_ids[0]
-    elif isinstance(gpu_device_id, list):
-        device_id = gpu_device_id[0] if gpu_device_id else None
-    else:
-        device_id = gpu_device_id
+    device_id = first_gpu_device_id(
+        resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
+    )
 
     device = "cuda" if device_id is None else f"cuda:{device_id}"
     return NeuralTissueSegmenter(device=device)
+
+
+def _build_segmentation_runtime(cfg: "TessellateExtractFeaturesConfig"):
+    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    neural_segmenter = _build_neural_segmenter(
+        seg_cfg,
+        cfg.use_gpu,
+        gpu_device_id=cfg.gpu_device_id,
+        gpu_device_ids=cfg.gpu_device_ids,
+    )
+    return artifact_remover_fn, neural_segmenter
 
 
 def _resolve_precision(cfg: "TessellateExtractFeaturesConfig", model_type) -> str:
@@ -627,15 +637,7 @@ def _main_single(cfg: TessellateExtractFeaturesConfig):
     )
     skip_second_extraction = use_filtering and models_are_same
 
-    artifact_remover_fn = _build_artifact_remover(
-        OmegaConf.to_container(cfg.seg_config)
-    )
-    neural_segmenter = _build_neural_segmenter(
-        OmegaConf.to_container(cfg.seg_config),
-        cfg.use_gpu,
-        gpu_device_id=cfg.gpu_device_id,
-        gpu_device_ids=cfg.gpu_device_ids,
-    )
+    artifact_remover_fn, neural_segmenter = _build_segmentation_runtime(cfg)
 
     # Process the slide using shared logic
     result = process_slide_tessellation_and_filtering(
@@ -817,15 +819,7 @@ def _main_batch(
 
     # Instantiate artifact remover once per batch so model weights are loaded
     # only once rather than once per slide.
-    artifact_remover_fn = _build_artifact_remover(
-        OmegaConf.to_container(cfg.seg_config)
-    )
-    neural_segmenter = _build_neural_segmenter(
-        OmegaConf.to_container(cfg.seg_config),
-        cfg.use_gpu,
-        gpu_device_id=cfg.gpu_device_id,
-        gpu_device_ids=cfg.gpu_device_ids,
-    )
+    artifact_remover_fn, neural_segmenter = _build_segmentation_runtime(cfg)
 
     slide_results = []
     for i, (slide_path, slide_id) in enumerate(zip(cfg.slide_paths, slide_ids)):

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -12,13 +12,22 @@ from shapely.geometry import Polygon
 
 logger = logging.getLogger(__name__)
 
+# isort: off
 from mussel.cli.tessellate import _build_artifact_remover
-from mussel.utils import (filter_features, is_remote_path, load_classifier,
-                          load_features_from_h5, safe_path_join, save_features,
-                          save_hdf5, save_torch_tensor)
+from mussel.utils import (
+    filter_features,
+    is_remote_path,
+    load_classifier,
+    load_features_from_h5,
+    safe_path_join,
+    save_features,
+    save_hdf5,
+    save_torch_tensor,
+)
 from mussel.utils.artifact_removal import GrandQCArtifactRemover
-from mussel.utils.segment import (draw_slide_mask, save_patches_png,
-                                  segment_tissue)
+from mussel.utils.segment import draw_slide_mask, save_patches_png, segment_tissue
+
+# isort: on
 
 
 def _tessellate_and_filter(
@@ -33,6 +42,7 @@ def _tessellate_and_filter(
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Tessellate a slide and optionally extract/filter features for tile selection.
 
@@ -93,6 +103,7 @@ def _tessellate_and_filter(
         slide_id=slide_id,
         output_h5_path=tessellate_h5_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values
@@ -213,6 +224,7 @@ def process_slide_tessellation_and_filtering(
     two_step_mode: bool = False,
     slide_model_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Process a single slide through tessellation, optional filtering, and feature extraction.
 
@@ -253,6 +265,7 @@ def process_slide_tessellation_and_filtering(
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     )
     if result is None:
         return None
@@ -351,6 +364,7 @@ def process_slide_tessellation_only(
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Process a slide through tessellation and optional filtering (no feature extraction).
 
@@ -385,6 +399,7 @@ def process_slide_tessellation_only(
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     )
     if result is None:
         return None

--- a/mussel/models/base.py
+++ b/mussel/models/base.py
@@ -15,6 +15,8 @@ from huggingface_hub import hf_hub_download
 from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
+from mussel.utils.gpu import first_gpu_device_id
+
 try:
     from mussel.utils.model_cache import model_download_lock
 except ImportError:
@@ -183,11 +185,7 @@ class TorchModel(Model):
             raise OSError("cuda not available")
 
         device_type = "cuda" if use_gpu else "cpu"
-        device_id = (
-            gpu_device_id[0]
-            if isinstance(gpu_device_id, list) and len(gpu_device_id) > 0
-            else gpu_device_id
-        )
+        device_id = first_gpu_device_id(gpu_device_id)
         self.device = (
             torch.device(device_type, device_id)
             if device_id is not None

--- a/mussel/utils/env.py
+++ b/mussel/utils/env.py
@@ -1,0 +1,29 @@
+import os
+import warnings
+from typing import Callable, Optional, TypeVar
+
+T = TypeVar("T", int, float)
+
+
+def parse_optional_positive_env(
+    env_name: str,
+    *,
+    default: T,
+    parser: Callable[[str], T],
+) -> Optional[T]:
+    """Parse a positive numeric env var, with non-positive values disabling it."""
+    value = os.environ.get(env_name)
+    if value is None:
+        return default
+    try:
+        parsed = parser(value)
+    except ValueError:
+        warnings.warn(
+            f"Invalid {env_name} value; using default {default}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return default
+    if parsed <= 0:
+        return None
+    return parsed

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import ImageFolder
 from tqdm import tqdm
 
+# fmt: off
 from mussel.datasets import (FlatImageDataset, WholeSlideImageH5Dataset,
                              WholeSlideImageTileCoordDataset)
 from mussel.models import (ModelType, get_default_patch_size,
@@ -23,8 +24,11 @@ from mussel.models import (ModelType, get_default_patch_size,
                            validate_slide_encoder_compatibility)
 
 from .file import save_hdf5, save_torch_tensor
+from .gpu import resolve_gpu_device_id
 from .ml import collate_features
 from .timer import timed
+
+# fmt: on
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +48,11 @@ def _numpy_to_torch(arr: np.ndarray, dtype: Optional[np.dtype] = None) -> torch.
     # Auto-detect |V2 (HDF5 bfloat16 representation) without requiring a dtype hint.
     if arr.dtype.kind == "V" and arr.dtype.itemsize == 2:
         arr = arr.view(ml_dtypes.bfloat16)
-    elif dtype is not None and dtype == np.dtype(ml_dtypes.bfloat16) and arr.dtype.kind == "V":
+    elif (
+        dtype is not None
+        and dtype == np.dtype(ml_dtypes.bfloat16)
+        and arr.dtype.kind == "V"
+    ):
         arr = arr.view(ml_dtypes.bfloat16)
     if arr.dtype == np.dtype(ml_dtypes.bfloat16):
         return torch.from_numpy(arr.view(np.uint16)).view(torch.bfloat16)
@@ -289,7 +297,9 @@ class H5DatasetProcessor(DatasetProcessor):
         # Concatenate all results
         empty_dtype = feature_dtype if feature_dtype is not None else np.float32
         features = (
-            np.concatenate(all_features, axis=0) if all_features else np.array([], dtype=empty_dtype)
+            np.concatenate(all_features, axis=0)
+            if all_features
+            else np.array([], dtype=empty_dtype)
         )
         coords = np.concatenate(all_coords, axis=0) if all_coords else np.array([])
 
@@ -384,7 +394,9 @@ class ImageFolderProcessor(DatasetProcessor):
         # Concatenate all results
         empty_dtype = feature_dtype if feature_dtype is not None else np.float32
         features = (
-            np.concatenate(all_features, axis=0) if all_features else np.array([], dtype=empty_dtype)
+            np.concatenate(all_features, axis=0)
+            if all_features
+            else np.array([], dtype=empty_dtype)
         )
         labels = np.concatenate(all_labels, axis=0) if all_labels else np.array([])
 
@@ -788,7 +800,9 @@ def _apply_slide_aggregation(
         return features
     elif aggregation_method == "mean":
         # Mean pooling across patches; upcast to float32 so numpy ufuncs work reliably.
-        aggregated_features = np.mean(features.astype(np.float32), axis=0, keepdims=True)
+        aggregated_features = np.mean(
+            features.astype(np.float32), axis=0, keepdims=True
+        )
         logger.info(
             f"Applied mean pooling: {features.shape} -> {aggregated_features.shape}"
         )
@@ -809,8 +823,7 @@ def _apply_slide_aggregation(
 
         logger.info(f"Using model-based aggregation with {slide_model_type}")
 
-        if gpu_device_ids:
-            gpu_device_id = gpu_device_ids
+        gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
         # Load or use pre-loaded slide encoder model
         if slide_model is not None:
@@ -820,7 +833,9 @@ def _apply_slide_aggregation(
             model_factory = get_model_factory(slide_model_type)
             if model_factory is None:
                 raise ValueError(f"Slide model type {slide_model_type} not recognized")
-            slide_model = model_factory.get_model(slide_model_path, use_gpu, gpu_device_id)
+            slide_model = model_factory.get_model(
+                slide_model_path, use_gpu, gpu_device_id
+            )
             model_fun = slide_model.get_model_fun()
 
         # Convert features to tensor (handles bfloat16/V2 correctly) and apply model
@@ -960,10 +975,11 @@ def get_features(
             )
     if slide_model is not None:
         if not callable(getattr(slide_model, "get_model_fun", None)):
-            raise TypeError("slide_model must provide a callable get_model_fun() method")
+            raise TypeError(
+                "slide_model must provide a callable get_model_fun() method"
+            )
 
-    if gpu_device_ids:
-        gpu_device_id = gpu_device_ids
+    gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
     # Auto-set aggregation_method unconditionally so pre-loaded models also trigger slide encoding.
     if (
@@ -978,7 +994,11 @@ def get_features(
         aggregation_method = "model"
 
     # Validate patch/slide encoder compatibility regardless of how models are provided.
-    if use_slide_encoder and aggregation_method == "model" and slide_model_type is not None:
+    if (
+        use_slide_encoder
+        and aggregation_method == "model"
+        and slide_model_type is not None
+    ):
         if model is None:
             # Auto-infer required patch encoder when loading from disk.
             required_patch_encoder = get_required_patch_encoder(slide_model_type)
@@ -1098,8 +1118,7 @@ def extract_patch_features(
     Returns:
         Path to the output HDF5 file containing patch-level features.
     """
-    if gpu_device_ids:
-        gpu_device_id = gpu_device_ids
+    gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
     logger.info("Step 1: Extracting patch-level features")
     logger.info("loading model checkpoint")
@@ -1243,8 +1262,7 @@ def extract_patch_features_batch(
     num_slides = len(patch_h5_paths)
     logger.info(f"Batch extracting patch-level features for {num_slides} slides")
 
-    if gpu_device_ids:
-        gpu_device_id = gpu_device_ids
+    gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
     feature_dtype = _parse_feature_dtype(embedding_precision)
 
@@ -1417,7 +1435,11 @@ def aggregate_slide_features_batch(
                     )
 
                     feature_dtype = _parse_feature_dtype(embedding_precision)
-                    features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+                    features_to_save = (
+                        aggregated_features.astype(feature_dtype)
+                        if feature_dtype is not None
+                        else aggregated_features
+                    )
 
                     # Save to HDF5 if requested
                     if output_h5:
@@ -1451,7 +1473,9 @@ def aggregate_slide_features_batch(
 
         if failed_slides:
             logger.warning(f"\n=== Batch Processing Summary ===")
-            logger.warning(f"Successfully processed: {len(successful_slides)}/{num_slides} slides")
+            logger.warning(
+                f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
+            )
             logger.warning(f"Failed: {len(failed_slides)} slides")
             logger.warning(f"Failed slides: {', '.join(failed_slides)}")
             if len(failed_slides) == num_slides:
@@ -1468,8 +1492,7 @@ def aggregate_slide_features_batch(
     # Model-based aggregation with batching
     logger.info(f"Using batch processing with slide_batch_size={slide_batch_size}")
 
-    if gpu_device_ids:
-        gpu_device_id = gpu_device_ids
+    gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
     # Resolve model_path from model_dir if provided
     if model_path is None and model_dir is not None:
@@ -1554,14 +1577,23 @@ def aggregate_slide_features_batch(
                         # Subsample patches if slide exceeds max_slide_patches.
                         # TITAN's alibi attention is O(N²) — large slides (>~8k patches)
                         # will OOM on most GPUs without subsampling.
-                        if max_slide_patches is not None and features.shape[0] > max_slide_patches:
+                        if (
+                            max_slide_patches is not None
+                            and features.shape[0] > max_slide_patches
+                        ):
                             logger.warning(
                                 f"Slide {slide_name} has {features.shape[0]} patches, "
                                 f"subsampling to {max_slide_patches} for TITAN_SLIDE "
                                 f"(O(N²) attention limit)."
                             )
-                            rng = np.random.default_rng(seed=abs(hash(slide_name)) % 2**32)
-                            indices = np.sort(rng.choice(features.shape[0], max_slide_patches, replace=False))
+                            rng = np.random.default_rng(
+                                seed=abs(hash(slide_name)) % 2**32
+                            )
+                            indices = np.sort(
+                                rng.choice(
+                                    features.shape[0], max_slide_patches, replace=False
+                                )
+                            )
                             features = features[indices]
                             coords = coords[indices]
 
@@ -1647,7 +1679,11 @@ def aggregate_slide_features_batch(
 
             try:
                 feature_dtype = _parse_feature_dtype(embedding_precision)
-                features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+                features_to_save = (
+                    aggregated_features.astype(feature_dtype)
+                    if feature_dtype is not None
+                    else aggregated_features
+                )
 
                 # Save to HDF5 if requested
                 if output_h5_paths and output_h5_paths[i] is not None:
@@ -1765,7 +1801,11 @@ def aggregate_slide_features(
         )
 
         feature_dtype = _parse_feature_dtype(embedding_precision)
-        features_to_save = aggregated_features.astype(feature_dtype) if feature_dtype is not None else aggregated_features
+        features_to_save = (
+            aggregated_features.astype(feature_dtype)
+            if feature_dtype is not None
+            else aggregated_features
+        )
 
         # Save to HDF5 if requested
         if output_h5_path is not None:
@@ -1915,8 +1955,7 @@ def save_features(
         )
     else:
         # Single-step process (backward compatible)
-        if gpu_device_ids:
-            gpu_device_id = gpu_device_ids
+        gpu_device_id = resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
 
         logger.info("loading model checkpoint")
 

--- a/mussel/utils/gpu.py
+++ b/mussel/utils/gpu.py
@@ -1,0 +1,18 @@
+from typing import List, Optional, Union
+
+GpuDeviceId = Union[int, List[int]]
+
+
+def resolve_gpu_device_id(
+    gpu_device_id: Optional[GpuDeviceId] = None,
+    gpu_device_ids: Optional[List[int]] = None,
+) -> Optional[GpuDeviceId]:
+    """Apply the common precedence for single- and multi-GPU CLI options."""
+    return gpu_device_ids if gpu_device_ids else gpu_device_id
+
+
+def first_gpu_device_id(gpu_device_id: Optional[GpuDeviceId] = None) -> Optional[int]:
+    """Return the first concrete GPU id from a scalar or multi-GPU value."""
+    if isinstance(gpu_device_id, list):
+        return gpu_device_id[0] if gpu_device_id else None
+    return gpu_device_id

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -34,6 +33,7 @@ from huggingface_hub import snapshot_download
 from torchvision.models.segmentation import deeplabv3_resnet50
 
 from mussel.models.base import IMAGENET_MEAN, IMAGENET_STD
+from mussel.utils.env import parse_optional_positive_env
 
 logger = logging.getLogger(__name__)
 
@@ -259,21 +259,11 @@ def _num_tiles(height: int, width: int, patch_size: int) -> int:
 
 
 def _get_max_inference_tiles() -> Optional[int]:
-    value = os.environ.get("MUSSEL_NEURAL_SEG_MAX_TILES")
-    if value is None:
-        return 4096
-    try:
-        parsed = int(value)
-    except ValueError:
-        warnings.warn(
-            "Invalid MUSSEL_NEURAL_SEG_MAX_TILES value; using default 4096.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return 4096
-    if parsed <= 0:
-        return None
-    return parsed
+    return parse_optional_positive_env(
+        "MUSSEL_NEURAL_SEG_MAX_TILES",
+        default=4096,
+        parser=int,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -31,8 +31,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from huggingface_hub import snapshot_download
-from PIL import Image
-from torchvision import transforms
 from torchvision.models.segmentation import deeplabv3_resnet50
 
 from mussel.models.base import IMAGENET_MEAN, IMAGENET_STD
@@ -75,6 +73,7 @@ class NeuralTissueSegmenter:
         device: str = "auto",
         batch_size: int = 8,
         confidence_thresh: float = 0.5,
+        max_inference_tiles: Optional[int] = None,
     ):
         if device == "auto":
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -83,9 +82,15 @@ class NeuralTissueSegmenter:
 
         self.batch_size = batch_size
         self.confidence_thresh = confidence_thresh
+        self.max_inference_tiles = (
+            _get_max_inference_tiles()
+            if max_inference_tiles is None
+            else max_inference_tiles
+        )
         self._model = None
         self._weights_path = weights_path
-        self._transform = None  # built lazily alongside the model
+        self._mean = None  # built lazily alongside the model
+        self._std = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -105,8 +110,6 @@ class NeuralTissueSegmenter:
             Binary uint8 mask of shape ``(H, W)`` where 255 = tissue and
             0 = background, at the same spatial resolution as ``img``.
         """
-        self._ensure_model_loaded()
-
         H, W = img.shape[:2]
 
         # 1. Rescale to target inference resolution (1 µm/px).
@@ -114,11 +117,28 @@ class NeuralTissueSegmenter:
         if scale != 1.0:
             target_H = max(1, int(round(H * scale)))
             target_W = max(1, int(round(W * scale)))
+        else:
+            target_H, target_W = H, W
+
+        n_tiles = _num_tiles(target_H, target_W, _INPUT_SIZE)
+        if self.max_inference_tiles is not None and n_tiles > self.max_inference_tiles:
+            raise ValueError(
+                "Neural tissue segmentation would require "
+                f"{n_tiles:,} {_INPUT_SIZE}x{_INPUT_SIZE} inference tiles "
+                f"after rescaling from {H}x{W} at {slide_mpp:.3f} µm/px "
+                f"to {target_H}x{target_W} at {_TARGET_MPP:.1f} µm/px. "
+                f"This exceeds max_inference_tiles={self.max_inference_tiles:,}. "
+                "Use a finer slide pyramid level or set MUSSEL_NEURAL_SEG_MAX_TILES=0 "
+                "to disable this guard."
+            )
+
+        self._ensure_model_loaded()
+
+        if scale != 1.0:
             resized = cv2.resize(
                 img, (target_W, target_H), interpolation=cv2.INTER_CUBIC
             )
         else:
-            target_H, target_W = H, W
             resized = img
 
         # 2. Tile into _INPUT_SIZE × _INPUT_SIZE patches and run inference.
@@ -145,12 +165,11 @@ class NeuralTissueSegmenter:
         self._model = self._model.to(self.device)
         if self.device.type == "cuda":
             self._model = self._model.half()
-        self._transform = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
-            ]
-        )
+        self._mean = torch.tensor(IMAGENET_MEAN, device=self.device).view(1, 3, 1, 1)
+        self._std = torch.tensor(IMAGENET_STD, device=self.device).view(1, 3, 1, 1)
+        if self.device.type == "cuda":
+            self._mean = self._mean.half()
+            self._std = self._std.half()
         logger.info(f"NeuralTissueSegmenter loaded on {self.device}")
 
     def _build_model(self, weights_path: str):
@@ -182,6 +201,9 @@ class NeuralTissueSegmenter:
         patch_size = _INPUT_SIZE
         full_mask = np.zeros((H, W), dtype=np.uint8)
 
+        use_fp16 = self.device.type == "cuda"
+        dtype = torch.float16 if use_fp16 else torch.float32
+
         patches: list[np.ndarray] = []
         positions: list[tuple[int, int, int, int]] = []
 
@@ -190,7 +212,6 @@ class NeuralTissueSegmenter:
                 crop = img[y : y + patch_size, x : x + patch_size]
                 y1 = min(y + patch_size, H)
                 x1 = min(x + patch_size, W)
-                # Pad to full patch_size if the crop is smaller (border tiles).
                 if crop.shape[0] < patch_size or crop.shape[1] < patch_size:
                     padded = np.zeros((patch_size, patch_size, 3), dtype=np.uint8)
                     padded[: crop.shape[0], : crop.shape[1]] = crop
@@ -198,28 +219,61 @@ class NeuralTissueSegmenter:
                 patches.append(crop)
                 positions.append((y, x, y1, x1))
 
-        use_fp16 = self.device.type == "cuda"
-        dtype = torch.float16 if use_fp16 else torch.float32
+                if len(patches) == self.batch_size:
+                    self._infer_batch(patches, positions, full_mask, dtype)
+                    patches = []
+                    positions = []
 
-        for batch_start in range(0, len(patches), self.batch_size):
-            batch = patches[batch_start : batch_start + self.batch_size]
-            batch_pos = positions[batch_start : batch_start + self.batch_size]
-
-            tensors = torch.stack(
-                [self._transform(Image.fromarray(p)) for p in batch]
-            ).to(self.device, dtype=dtype)
-
-            with torch.no_grad():
-                logits = self._model(tensors)["out"]  # (B, 2, 512, 512)
-                probs = F.softmax(logits.float(), dim=1)
-                # Channel 1 = tissue probability.
-                preds = (probs[:, 1] > self.confidence_thresh).to(torch.uint8)
-                preds = preds.cpu().numpy()  # (B, 512, 512)
-
-            for pred, (y0, x0, y1, x1) in zip(preds, batch_pos):
-                full_mask[y0:y1, x0:x1] = pred[: y1 - y0, : x1 - x0]
+        if patches:
+            self._infer_batch(patches, positions, full_mask, dtype)
 
         return full_mask  # values 0 or 1
+
+    def _infer_batch(
+        self,
+        patches: list[np.ndarray],
+        positions: list[tuple[int, int, int, int]],
+        full_mask: np.ndarray,
+        dtype: torch.dtype,
+    ) -> None:
+        batch_np = np.stack(patches, axis=0)
+        tensors = torch.from_numpy(batch_np).permute(0, 3, 1, 2)
+        tensors = tensors.to(self.device, dtype=dtype).div_(255.0)
+        tensors = (tensors - self._mean) / self._std
+
+        with torch.no_grad():
+            logits = self._model(tensors)["out"]  # (B, 2, 512, 512)
+            probs = F.softmax(logits.float(), dim=1)
+            # Channel 1 = tissue probability.
+            preds = (probs[:, 1] > self.confidence_thresh).to(torch.uint8)
+            preds = preds.cpu().numpy()  # (B, 512, 512)
+
+        for pred, (y0, x0, y1, x1) in zip(preds, positions):
+            full_mask[y0:y1, x0:x1] = pred[: y1 - y0, : x1 - x0]
+
+
+def _num_tiles(height: int, width: int, patch_size: int) -> int:
+    return ((height + patch_size - 1) // patch_size) * (
+        (width + patch_size - 1) // patch_size
+    )
+
+
+def _get_max_inference_tiles() -> Optional[int]:
+    value = os.environ.get("MUSSEL_NEURAL_SEG_MAX_TILES")
+    if value is None:
+        return 4096
+    try:
+        parsed = int(value)
+    except ValueError:
+        warnings.warn(
+            "Invalid MUSSEL_NEURAL_SEG_MAX_TILES value; using default 4096.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return 4096
+    if parsed <= 0:
+        return None
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -1,6 +1,8 @@
 import functools
 import logging
+import math
 import multiprocessing as mp
+import os
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +27,9 @@ logger = logging.getLogger(__name__)
 
 _SEGMENT_THRESHOLD_DEFAULT = 20
 _MEDIAN_BLUR_DEFAULT = 7
+_NEURAL_TARGET_MPP = 1.0
+_NEURAL_MAX_AUTO_UPSCALE = 2.25
+_NEURAL_MAX_UPSCALE_ENV = "MUSSEL_NEURAL_SEG_MAX_UPSCALE"
 
 
 def get_slide_mpp(
@@ -179,6 +184,74 @@ def get_level_for_magnification(wsi, target_mag: float, fallback_level: int = 2)
         return wsi.get_best_level_for_downsample(downsample)
     except Exception:
         return fallback_level
+
+
+def _get_neural_seg_level(wsi, slide_mpp: float, level_downsamples) -> int:
+    """Choose a pyramid level near the neural model's native resolution.
+
+    Prefer levels at 1 µm/px or up to ~2× coarser. This avoids reading a huge
+    full-resolution image when a near-target pyramid level exists, while
+    preventing the very coarse 16×-style thumbnail upsampling that breaks the
+    neural model's input semantics.
+    """
+    level_mpps = [slide_mpp * ds[0] for ds in level_downsamples]
+    acceptable_coarser = [
+        (idx, level_mpp)
+        for idx, level_mpp in enumerate(level_mpps)
+        if _NEURAL_TARGET_MPP
+        <= level_mpp
+        <= _NEURAL_TARGET_MPP * _NEURAL_MAX_AUTO_UPSCALE
+    ]
+    if acceptable_coarser:
+        return min(acceptable_coarser, key=lambda item: item[1])[0]
+
+    finer_or_equal = [
+        (idx, level_mpp)
+        for idx, level_mpp in enumerate(level_mpps)
+        if level_mpp <= _NEURAL_TARGET_MPP
+    ]
+    if finer_or_equal:
+        return max(finer_or_equal, key=lambda item: item[1])[0]
+
+    return min(
+        range(len(level_mpps)),
+        key=lambda idx: abs(math.log(level_mpps[idx] / _NEURAL_TARGET_MPP)),
+    )
+
+
+def _get_neural_max_upscale() -> Optional[float]:
+    value = os.environ.get(_NEURAL_MAX_UPSCALE_ENV)
+    if value is None:
+        return _NEURAL_MAX_AUTO_UPSCALE
+    try:
+        parsed = float(value)
+    except ValueError:
+        warnings.warn(
+            f"Invalid {_NEURAL_MAX_UPSCALE_ENV} value; using default "
+            f"{_NEURAL_MAX_AUTO_UPSCALE}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _NEURAL_MAX_AUTO_UPSCALE
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def _validate_neural_seg_mpp(seg_level_mpp: float, seg_level: int) -> None:
+    max_upscale = _get_neural_max_upscale()
+    if max_upscale is None:
+        return
+    max_mpp = _NEURAL_TARGET_MPP * max_upscale
+    if seg_level_mpp <= max_mpp:
+        return
+    raise ValueError(
+        f"seg_model='neural' cannot use seg_level={seg_level} at "
+        f"{seg_level_mpp:.3f} µm/px because that would require "
+        f"{seg_level_mpp / _NEURAL_TARGET_MPP:.1f}x upsampling to the "
+        f"{_NEURAL_TARGET_MPP:.1f} µm/px neural model resolution. "
+        f"Use a finer seg_level or set {_NEURAL_MAX_UPSCALE_ENV}=0 to disable this guard."
+    )
 
 
 def is_white_patch(patch, saturation_threshold=5):
@@ -480,7 +553,9 @@ def _filter_contours(
     return foreground_contours, hole_contours
 
 
-def _segment_tissue_neural(img: np.ndarray, slide_mpp: float) -> np.ndarray:
+def _segment_tissue_neural(
+    img: np.ndarray, slide_mpp: float, segmenter=None
+) -> np.ndarray:
     """Generate a binary tissue mask using Mussel's native neural segmentor.
 
     Uses a DeepLabV3-ResNet50 model (pre-trained on histopathology slides) to
@@ -501,7 +576,8 @@ def _segment_tissue_neural(img: np.ndarray, slide_mpp: float) -> np.ndarray:
     """
     from mussel.utils.neural_seg import NeuralTissueSegmenter
 
-    segmenter = NeuralTissueSegmenter()
+    if segmenter is None:
+        segmenter = NeuralTissueSegmenter()
     return segmenter.segment(img, slide_mpp=slide_mpp)
 
 
@@ -532,6 +608,7 @@ def segment_tissue(
     artifact_remover_fn=None,  # Optional callable: (img, mask, mpp) -> mask
     seg_model: str = "classic",  # "classic" (HSV + manual threshold), "otsu" (HSV + Otsu threshold), or "neural" (DeepLabV3)
     slide_mpp_override: Optional[float] = None,
+    neural_segmenter=None,
 ):
     """Segment tissue regions in a whole-slide image and generate tissue patches.
 
@@ -631,62 +708,9 @@ def segment_tissue(
         if keep_ids is None:
             keep_ids = []
 
-        if seg_level < 0:
-            if len(wsi.level_dimensions) == 1:
-                seg_level = 0
-            else:
-                seg_level = wsi.get_best_level_for_downsample(64)
-
-        logger.info(f"Using level {seg_level} for segmentation")
-        width, height = wsi.level_dimensions[seg_level]
-        if width * height > 1e12:
-            logger.error(
-                "level_dim {} x {} is likely too large for successful segmentation, aborting".format(
-                    width, height
-                )
-            )
-            return None
-
-        if step_size is None:
-            if overlap < 0:
-                raise ValueError(f"overlap must be non-negative, got {overlap}")
-            if overlap > 0:
-                step_size = patch_size - overlap
-                if step_size <= 0:
-                    raise ValueError(
-                        f"overlap ({overlap}) must be less than patch_size ({patch_size})"
-                    )
-            else:
-                step_size = patch_size
-        elif overlap > 0:
-            raise ValueError(
-                f"Cannot specify both step_size ({step_size}) and overlap ({overlap}). "
-                "Use overlap to derive step_size automatically, or pass step_size directly."
-            )
-
-        # Get MPP with fallback handling.
-        # Probe without a default first to detect whether real metadata exists.
-        _mpp_probe = get_slide_mpp(
-            wsi, slide_path, default_mpp=None, slide_mpp_override=slide_mpp_override
-        )
-        slide_mpp = _mpp_probe if _mpp_probe is not None else get_slide_mpp(
-            wsi, slide_path, slide_mpp_override=slide_mpp_override
-        )
-        # True when no MPP metadata was found and the 0.5 µm/px default was used.
-        mpp_is_fallback = _mpp_probe is None and slide_mpp_override is None
-
-        native_step_size = get_native_size(step_size, mpp, slide_mpp)
-        native_patch_size = get_native_size(patch_size, mpp, slide_mpp)
-        logger.info(f"native_step_size: {native_step_size}")
-        logger.info(f"native_patch_size: {native_patch_size}")
-
-        img = np.array(
-            wsi.read_region((0, 0), seg_level, wsi.level_dimensions[seg_level])
-        )
-
-        level_downsamples = _assert_level_downsamples(wsi)
-
-        # Validate and normalise seg_model
+        # Validate and normalise seg_model before choosing the segmentation level.
+        # Neural segmentation needs a materially finer source image than the
+        # classic HSV thumbnail path.
         supported_seg_models = {"classic", "otsu", "neural"}
         if seg_model is None:
             seg_model = "classic"
@@ -710,6 +734,72 @@ def segment_tissue(
             )
             seg_model = "otsu"
 
+        # Get MPP with fallback handling.
+        # Probe without a default first to detect whether real metadata exists.
+        _mpp_probe = get_slide_mpp(
+            wsi, slide_path, default_mpp=None, slide_mpp_override=slide_mpp_override
+        )
+        slide_mpp = (
+            _mpp_probe
+            if _mpp_probe is not None
+            else get_slide_mpp(wsi, slide_path, slide_mpp_override=slide_mpp_override)
+        )
+        # True when no MPP metadata was found and the 0.5 µm/px default was used.
+        mpp_is_fallback = _mpp_probe is None and slide_mpp_override is None
+
+        level_downsamples = _assert_level_downsamples(wsi)
+
+        if seg_level < 0:
+            if len(wsi.level_dimensions) == 1:
+                seg_level = 0
+            elif seg_model == "neural":
+                seg_level = _get_neural_seg_level(wsi, slide_mpp, level_downsamples)
+            else:
+                seg_level = wsi.get_best_level_for_downsample(64)
+
+        logger.info(f"Using level {seg_level} for segmentation")
+        width, height = wsi.level_dimensions[seg_level]
+        if width * height > 1e12:
+            logger.error(
+                "level_dim {} x {} is likely too large for successful segmentation, aborting".format(
+                    width, height
+                )
+            )
+            return None
+
+        if seg_model == "neural":
+            seg_level_ds = level_downsamples[seg_level][0]
+            seg_level_mpp = slide_mpp * seg_level_ds
+            _validate_neural_seg_mpp(seg_level_mpp, seg_level)
+
+        if step_size is None:
+            if overlap < 0:
+                raise ValueError(f"overlap must be non-negative, got {overlap}")
+            if overlap > 0:
+                step_size = patch_size - overlap
+                if step_size <= 0:
+                    raise ValueError(
+                        f"overlap ({overlap}) must be less than patch_size ({patch_size})"
+                    )
+            else:
+                step_size = patch_size
+        elif overlap > 0:
+            raise ValueError(
+                f"Cannot specify both step_size ({step_size}) and overlap ({overlap}). "
+                "Use overlap to derive step_size automatically, or pass step_size directly."
+            )
+
+        native_step_size = get_native_size(step_size, mpp, slide_mpp)
+        native_patch_size = get_native_size(patch_size, mpp, slide_mpp)
+        logger.info(f"native_step_size: {native_step_size}")
+        logger.info(f"native_patch_size: {native_patch_size}")
+
+        img = np.array(
+            wsi.read_region((0, 0), seg_level, wsi.level_dimensions[seg_level])
+        )
+        if img.ndim == 3 and img.shape[2] > 3:
+            img = img[:, :, :3]
+
         # Warn about classic-only parameters that are ignored by the neural backend.
         if seg_model == "neural":
             ignored = []
@@ -727,9 +817,9 @@ def segment_tissue(
         if seg_model == "neural":
             # The img is read at seg_level. Compute its actual MPP so that
             # NeuralTissueSegmenter can rescale to the model's 1 µm/px target.
-            seg_level_ds = level_downsamples[seg_level][0]  # x-axis downsample
-            seg_level_mpp = slide_mpp * seg_level_ds
-            tissue_mask = _segment_tissue_neural(img, seg_level_mpp)
+            tissue_mask = _segment_tissue_neural(
+                img, seg_level_mpp, segmenter=neural_segmenter
+            )
         else:
             img_hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)  # Convert to HSV space
             img_med = cv2.medianBlur(
@@ -768,7 +858,9 @@ def segment_tissue(
                 if max_mpp is not None and img_mpp >= max_mpp:
                     target_ds = max_mpp / slide_mpp
                     artifact_level = wsi.get_best_level_for_downsample(target_ds)
-                    artifact_level_mpp = slide_mpp * level_downsamples[artifact_level][0]
+                    artifact_level_mpp = (
+                        slide_mpp * level_downsamples[artifact_level][0]
+                    )
                     if artifact_level_mpp <= max_mpp:
                         remover_img = np.array(
                             wsi.read_region(
@@ -792,7 +884,9 @@ def segment_tissue(
                         )
 
                 pre_removal_mask = tissue_mask.copy()
-                result_mask = artifact_remover_fn(remover_img, remover_mask, remover_mpp)
+                result_mask = artifact_remover_fn(
+                    remover_img, remover_mask, remover_mpp
+                )
 
                 # Resize result back to seg-level dimensions if needed.
                 if result_mask.shape != tissue_mask.shape:
@@ -807,7 +901,9 @@ def segment_tissue(
                 # revert to the pre-removal mask.  Over-aggressive removal can
                 # occur when the GrandQC model is out-of-distribution for a
                 # particular tissue type (e.g. necrotic CNS tumours).
-                _MIN_TISSUE_SURVIVAL = 0.10  # at least 10% of original tissue must remain
+                _MIN_TISSUE_SURVIVAL = (
+                    0.10  # at least 10% of original tissue must remain
+                )
                 pre_pixels = int(np.count_nonzero(pre_removal_mask))
                 post_pixels = int(np.count_nonzero(result_mask))
                 removal_fraction = (
@@ -994,9 +1090,19 @@ def draw_slide_mask(
             scaled_polygon = scale_geometry(polygon, scale[0])
             if isinstance(polygon, MultiPolygon):
                 for geom in scaled_polygon.geoms:
-                    draw.polygon(geom.exterior.coords, outline=outline, fill=fill, width=outline_width)
+                    draw.polygon(
+                        geom.exterior.coords,
+                        outline=outline,
+                        fill=fill,
+                        width=outline_width,
+                    )
             else:
-                draw.polygon(scaled_polygon.exterior.coords, outline=outline, fill=fill, width=outline_width)
+                draw.polygon(
+                    scaled_polygon.exterior.coords,
+                    outline=outline,
+                    fill=fill,
+                    width=outline_width,
+                )
 
         image_width, image_height = img.size
         if custom_downsample and custom_downsample > 1:

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -17,6 +17,7 @@ from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import transform
 from shapely.prepared import prep
 
+from mussel.utils.env import parse_optional_positive_env
 from mussel.utils.file import save_hdf5
 from mussel.utils.timer import timed
 from mussel.utils.wsi_backend import open_slide as _wsi_open_slide
@@ -220,22 +221,11 @@ def _get_neural_seg_level(wsi, slide_mpp: float, level_downsamples) -> int:
 
 
 def _get_neural_max_upscale() -> Optional[float]:
-    value = os.environ.get(_NEURAL_MAX_UPSCALE_ENV)
-    if value is None:
-        return _NEURAL_MAX_AUTO_UPSCALE
-    try:
-        parsed = float(value)
-    except ValueError:
-        warnings.warn(
-            f"Invalid {_NEURAL_MAX_UPSCALE_ENV} value; using default "
-            f"{_NEURAL_MAX_AUTO_UPSCALE}.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return _NEURAL_MAX_AUTO_UPSCALE
-    if parsed <= 0:
-        return None
-    return parsed
+    return parse_optional_positive_env(
+        _NEURAL_MAX_UPSCALE_ENV,
+        default=_NEURAL_MAX_AUTO_UPSCALE,
+        parser=float,
+    )
 
 
 def _validate_neural_seg_mpp(seg_level_mpp: float, seg_level: int) -> None:

--- a/tests/mussel/cli/test_tessellate_extract_features.py
+++ b/tests/mussel/cli/test_tessellate_extract_features.py
@@ -74,42 +74,24 @@ def test_neural_segmenter_use_gpu_true_requires_cuda():
             _build_neural_segmenter(seg_cfg, use_gpu=True)
 
 
-def test_neural_segmenter_use_gpu_true_uses_cuda_when_available():
+@pytest.mark.parametrize(
+    ("kwargs", "expected_device"),
+    [
+        ({}, "cuda"),
+        ({"gpu_device_id": 2}, "cuda:2"),
+        ({"gpu_device_ids": [3, 4]}, "cuda:3"),
+    ],
+)
+def test_neural_segmenter_use_gpu_true_uses_cuda_device(kwargs, expected_device):
     seg_cfg = {"seg_model": "neural"}
 
     with (
         patch("torch.cuda.is_available", return_value=True),
         patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
     ):
-        result = _build_neural_segmenter(seg_cfg, use_gpu=True)
+        result = _build_neural_segmenter(seg_cfg, use_gpu=True, **kwargs)
 
-    MockSegmenter.assert_called_once_with(device="cuda")
-    assert result is MockSegmenter.return_value
-
-
-def test_neural_segmenter_use_gpu_true_uses_requested_cuda_device():
-    seg_cfg = {"seg_model": "neural"}
-
-    with (
-        patch("torch.cuda.is_available", return_value=True),
-        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
-    ):
-        result = _build_neural_segmenter(seg_cfg, use_gpu=True, gpu_device_id=2)
-
-    MockSegmenter.assert_called_once_with(device="cuda:2")
-    assert result is MockSegmenter.return_value
-
-
-def test_neural_segmenter_use_gpu_true_uses_first_multi_gpu_device():
-    seg_cfg = {"seg_model": "neural"}
-
-    with (
-        patch("torch.cuda.is_available", return_value=True),
-        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
-    ):
-        result = _build_neural_segmenter(seg_cfg, use_gpu=True, gpu_device_ids=[3, 4])
-
-    MockSegmenter.assert_called_once_with(device="cuda:3")
+    MockSegmenter.assert_called_once_with(device=expected_device)
     assert result is MockSegmenter.return_value
 
 

--- a/tests/mussel/cli/test_tessellate_extract_features.py
+++ b/tests/mussel/cli/test_tessellate_extract_features.py
@@ -8,8 +8,15 @@ import torch
 from omegaconf import OmegaConf
 
 from mussel.cli.tessellate import SegConfig
+
+# isort: off
 from mussel.cli.tessellate_extract_features import (
-    TessellateExtractFeaturesConfig, main)
+    TessellateExtractFeaturesConfig,
+    _build_neural_segmenter,
+    main,
+)
+
+# isort: on
 from mussel.models import ModelType
 
 _TEF_REQUIRED = dict(
@@ -47,6 +54,63 @@ def test_explicit_patch_size_preserved():
         seg_config=SegConfig(patch_size=384),
     )
     assert cfg.seg_config.patch_size == 384
+
+
+def test_neural_segmenter_use_gpu_false_forces_cpu():
+    seg_cfg = {"seg_model": "neural"}
+
+    with patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter:
+        result = _build_neural_segmenter(seg_cfg, use_gpu=False, gpu_device_id=1)
+
+    MockSegmenter.assert_called_once_with(device="cpu")
+    assert result is MockSegmenter.return_value
+
+
+def test_neural_segmenter_use_gpu_true_requires_cuda():
+    seg_cfg = {"seg_model": "neural"}
+
+    with patch("torch.cuda.is_available", return_value=False):
+        with pytest.raises(RuntimeError, match="CUDA is not available"):
+            _build_neural_segmenter(seg_cfg, use_gpu=True)
+
+
+def test_neural_segmenter_use_gpu_true_uses_cuda_when_available():
+    seg_cfg = {"seg_model": "neural"}
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
+    ):
+        result = _build_neural_segmenter(seg_cfg, use_gpu=True)
+
+    MockSegmenter.assert_called_once_with(device="cuda")
+    assert result is MockSegmenter.return_value
+
+
+def test_neural_segmenter_use_gpu_true_uses_requested_cuda_device():
+    seg_cfg = {"seg_model": "neural"}
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
+    ):
+        result = _build_neural_segmenter(seg_cfg, use_gpu=True, gpu_device_id=2)
+
+    MockSegmenter.assert_called_once_with(device="cuda:2")
+    assert result is MockSegmenter.return_value
+
+
+def test_neural_segmenter_use_gpu_true_uses_first_multi_gpu_device():
+    seg_cfg = {"seg_model": "neural"}
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
+    ):
+        result = _build_neural_segmenter(seg_cfg, use_gpu=True, gpu_device_ids=[3, 4])
+
+    MockSegmenter.assert_called_once_with(device="cuda:3")
+    assert result is MockSegmenter.return_value
 
 
 @pytest.mark.slow

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -14,8 +14,7 @@ import torch.nn as nn
 
 def _make_segmenter(model_obj=None, device="cpu"):
     """Return a NeuralTissueSegmenter with a pre-loaded mock model."""
-    from torchvision import transforms
-
+    from mussel.models.base import IMAGENET_MEAN, IMAGENET_STD
     from mussel.utils.neural_seg import NeuralTissueSegmenter
 
     seg = NeuralTissueSegmenter.__new__(NeuralTissueSegmenter)
@@ -23,11 +22,14 @@ def _make_segmenter(model_obj=None, device="cpu"):
     seg.confidence_thresh = 0.5
     seg.device = torch.device(device)
     seg._weights_path = None
-    seg._transform = transforms.Compose(
-        [
-            transforms.ToTensor(),
-        ]
+    dtype = torch.float16 if seg.device.type == "cuda" else torch.float32
+    seg._mean = torch.tensor(IMAGENET_MEAN, device=seg.device, dtype=dtype).view(
+        1, 3, 1, 1
     )
+    seg._std = torch.tensor(IMAGENET_STD, device=seg.device, dtype=dtype).view(
+        1, 3, 1, 1
+    )
+    seg.max_inference_tiles = 4096
     seg._model = model_obj
     return seg
 
@@ -148,6 +150,21 @@ class TestSlideMppRescaling:
         seg = _make_segmenter(_all_tissue_model())
         mask = seg.segment(img, slide_mpp=0.5)
         assert mask.shape == (1024, 1024)
+
+    def test_inference_tile_guard_blocks_accidental_massive_runs(self):
+        """The guard fails fast before model inference when rescaling explodes."""
+        from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+        img = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+        seg = NeuralTissueSegmenter(device="cpu", max_inference_tiles=1)
+
+        with patch.object(seg, "_ensure_model_loaded") as mock_load:
+            with patch("mussel.utils.neural_seg.cv2.resize") as mock_resize:
+                with pytest.raises(ValueError, match="max_inference_tiles"):
+                    seg.segment(img, slide_mpp=16.0)
+
+        mock_load.assert_not_called()
+        mock_resize.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1098,7 +1098,9 @@ class TestSegmentTissueArtifactRemover:
         ), "Warning should use >= symbol in threshold message"
 
         # Fallback reverts to pre-removal mask → tissue still present → patches found
-        assert result is not None, "segment_tissue should not return None after fallback"
+        assert (
+            result is not None
+        ), "segment_tissue should not return None after fallback"
         _, _, coords, _ = result
         assert len(coords) > 0, "Pre-removal mask should yield patches after fallback"
 
@@ -1127,7 +1129,9 @@ class TestSegmentTissueArtifactRemover:
 
         assert len(call_count) == 1, "remover should have been called exactly once"
         # half_remover only keeps bottom tissue → should still produce some patches
-        assert result_with_removal is not None, "Should not return None when tissue survives"
+        assert (
+            result_with_removal is not None
+        ), "Should not return None when tissue survives"
 
     def test_tissue_survival_boundary_at_exactly_90pct_triggers_fallback(self, caplog):
         """Removal fraction == 0.90 (exactly at threshold) should trigger fallback."""
@@ -1136,6 +1140,7 @@ class TestSegmentTissueArtifactRemover:
         def exactly_90pct_remover(img, mask, mpp):
             # Zero out exactly 90% of the nonzero pixels using ceil so we hit exactly >=90%
             import math
+
             flat = mask.flatten()
             nonzero_idx = np.flatnonzero(flat)
             n_to_zero = math.ceil(len(nonzero_idx) * 0.90)
@@ -1170,7 +1175,9 @@ class TestSegmentTissueArtifactRemover:
 
         # All-gray uniform image → saturation channel = 0 → tissue mask is all-zero
         # (classic segmenter thresholds on HSV saturation; gray has S=0 < threshold=20)
-        mock_wsi = _make_mock_wsi_with_tissue()  # uniform-gray → no tissue after segmentation
+        mock_wsi = (
+            _make_mock_wsi_with_tissue()
+        )  # uniform-gray → no tissue after segmentation
 
         with caplog.at_level(logging.WARNING, logger="mussel.utils.segment"):
             _run_segment_with_mocks(
@@ -1183,7 +1190,9 @@ class TestSegmentTissueArtifactRemover:
             )
 
         # Remover IS called even when tissue mask is all-zero (no early-return before remover block)
-        assert len(call_count) == 1, "remover is called regardless of tissue mask content"
+        assert (
+            len(call_count) == 1
+        ), "remover is called regardless of tissue mask content"
         # pre_pixels=0 → removal_fraction=1.0 → fallback triggered
         assert any(
             "Falling back to pre-removal mask" in msg for msg in caplog.messages
@@ -1196,7 +1205,9 @@ class TestSegmentTissueArtifactRemover:
         call_args = []
 
         def mpp_checking_remover(img, mask, mpp):
-            call_args.append({"img_shape": img.shape, "mask_shape": mask.shape, "mpp": mpp})
+            call_args.append(
+                {"img_shape": img.shape, "mask_shape": mask.shape, "mpp": mpp}
+            )
             return mask
 
         mpp_checking_remover.max_input_mpp = 4.0  # requires <= 4 µm/px
@@ -1219,8 +1230,9 @@ class TestSegmentTissueArtifactRemover:
 
         mock_wsi.read_region.side_effect = smart_read
 
-        from mussel.utils.segment import segment_tissue
         from unittest.mock import patch as _patch
+
+        from mussel.utils.segment import segment_tissue
 
         with (
             _patch("mussel.utils.segment.tiffslide.open_slide", return_value=mock_wsi),
@@ -1242,13 +1254,13 @@ class TestSegmentTissueArtifactRemover:
 
         assert len(call_args) == 1, "remover should be called once"
         # At escalation, level 0 mpp = 0.5 * 1.0 = 0.5 < max_input_mpp=4.0
-        assert call_args[0]["mpp"] == pytest.approx(0.5), (
-            f"Expected escalated mpp=0.5, got {call_args[0]['mpp']}"
-        )
+        assert call_args[0]["mpp"] == pytest.approx(
+            0.5
+        ), f"Expected escalated mpp=0.5, got {call_args[0]['mpp']}"
         # The fine-level image should be larger than the 512×512 coarse seg thumbnail
-        assert call_args[0]["img_shape"][0] == 4096, (
-            "Remover should receive the finer-level thumbnail, not the coarse seg thumbnail"
-        )
+        assert (
+            call_args[0]["img_shape"][0] == 4096
+        ), "Remover should receive the finer-level thumbnail, not the coarse seg thumbnail"
 
     def test_mpp_escalation_skipped_when_img_mpp_below_max(self):
         """When img_mpp < max_input_mpp, the seg-level thumbnail is used directly."""
@@ -1277,13 +1289,13 @@ class TestSegmentTissueArtifactRemover:
 
         assert len(call_args) == 1
         # img_mpp = 0.5 * 4.0 = 2.0 (seg level, not escalated)
-        assert call_args[0]["mpp"] == pytest.approx(2.0), (
-            f"Expected seg-level mpp=2.0, got {call_args[0]['mpp']}"
-        )
+        assert call_args[0]["mpp"] == pytest.approx(
+            2.0
+        ), f"Expected seg-level mpp=2.0, got {call_args[0]['mpp']}"
         # Thumbnail should be 1024×1024 (4096/4), the seg-level size
-        assert call_args[0]["img_shape"][0] == 1024, (
-            "Should use seg-level thumbnail when mpp is within limit"
-        )
+        assert (
+            call_args[0]["img_shape"][0] == 1024
+        ), "Should use seg-level thumbnail when mpp is within limit"
 
 
 class TestSegmentTissueSegModel:
@@ -1397,6 +1409,137 @@ class TestSegmentTissueSegModel:
                 seg_model="neural",
             )
             mock_neural.assert_called_once()
+
+    def test_neural_auto_seg_level_avoids_coarse_thumbnail_upsampling(self):
+        """Auto neural mode chooses a near-target level instead of the 64x thumbnail."""
+        mock_wsi = MagicMock()
+        mock_wsi.level_dimensions = [
+            (85656, 19917),
+            (21414, 4979),
+            (5353, 1244),
+            (2676, 622),
+        ]
+        mock_wsi.level_downsamples = [1.0, 4.0, 16.0, 32.0]
+
+        def read_region(_origin, level, dims):
+            width, height = dims
+            return np.ones((height, width, 3), dtype=np.uint8) * 200
+
+        mock_wsi.read_region.side_effect = read_region
+        fake_mask = np.zeros((4979, 21414), dtype=np.uint8)
+        fake_mask[100:200, 100:200] = 255
+
+        with (
+            patch("mussel.utils.segment.tiffslide.open_slide", return_value=mock_wsi),
+            patch("mussel.utils.segment.get_slide_mpp", return_value=0.5026),
+            patch(
+                "mussel.utils.segment._assert_level_downsamples",
+                return_value=[
+                    (1.0, 1.0),
+                    (4.0, 4.0),
+                    (16.0, 16.0),
+                    (32.0, 32.0),
+                ],
+            ),
+            patch(
+                "mussel.utils.segment._segment_tissue_neural",
+                return_value=fake_mask,
+            ) as mock_neural,
+        ):
+            from mussel.utils.segment import segment_tissue
+
+            segment_tissue(
+                "/fake/slide.svs",
+                patch_size=256,
+                mpp=0.5,
+                tissue_area_threshold=1,
+                seg_model="neural",
+            )
+
+        read_level = mock_wsi.read_region.call_args.args[1]
+        assert read_level == 1
+        neural_img, neural_mpp = mock_neural.call_args.args[:2]
+        assert neural_img.shape[:2] == (4979, 21414)
+        assert neural_mpp == pytest.approx(0.5026 * 4.0)
+
+    def test_neural_explicit_coarse_seg_level_raises_before_read(self, monkeypatch):
+        """Manual coarse neural seg_level cannot silently reintroduce huge upsampling."""
+        monkeypatch.delenv("MUSSEL_NEURAL_SEG_MAX_UPSCALE", raising=False)
+
+        mock_wsi = MagicMock()
+        mock_wsi.level_dimensions = [
+            (85656, 19917),
+            (21414, 4979),
+            (5353, 1244),
+            (2676, 622),
+        ]
+        mock_wsi.level_downsamples = [1.0, 4.0, 16.0, 32.0]
+
+        with (
+            patch("mussel.utils.segment._wsi_open_slide", return_value=mock_wsi),
+            patch("mussel.utils.segment.get_slide_mpp", return_value=0.5026),
+            patch(
+                "mussel.utils.segment._assert_level_downsamples",
+                return_value=[
+                    (1.0, 1.0),
+                    (4.0, 4.0),
+                    (16.0, 16.0),
+                    (32.0, 32.0),
+                ],
+            ),
+            patch("mussel.utils.segment._segment_tissue_neural") as mock_neural,
+        ):
+            from mussel.utils.segment import segment_tissue
+
+            with pytest.raises(ValueError, match="would require 16.1x upsampling"):
+                segment_tissue(
+                    "/fake/slide.svs",
+                    patch_size=256,
+                    mpp=0.5,
+                    tissue_area_threshold=1,
+                    seg_model="neural",
+                    seg_level=3,
+                )
+
+        mock_wsi.read_region.assert_not_called()
+        mock_neural.assert_not_called()
+
+    def test_neural_explicit_coarse_seg_level_allows_env_override(self, monkeypatch):
+        """The coarse-level guard can be disabled for intentional expert use."""
+        monkeypatch.setenv("MUSSEL_NEURAL_SEG_MAX_UPSCALE", "0")
+
+        mock_wsi = MagicMock()
+        mock_wsi.level_dimensions = [(4096, 4096), (1024, 1024)]
+        mock_wsi.level_downsamples = [1.0, 8.0]
+        mock_wsi.read_region.return_value = np.ones((1024, 1024, 3), dtype=np.uint8)
+        fake_mask = np.zeros((1024, 1024), dtype=np.uint8)
+        fake_mask[100:200, 100:200] = 255
+
+        with (
+            patch("mussel.utils.segment._wsi_open_slide", return_value=mock_wsi),
+            patch("mussel.utils.segment.get_slide_mpp", return_value=0.5),
+            patch(
+                "mussel.utils.segment._assert_level_downsamples",
+                return_value=[(1.0, 1.0), (8.0, 8.0)],
+            ),
+            patch(
+                "mussel.utils.segment._segment_tissue_neural",
+                return_value=fake_mask,
+            ) as mock_neural,
+        ):
+            from mussel.utils.segment import segment_tissue
+
+            segment_tissue(
+                "/fake/slide.svs",
+                patch_size=256,
+                mpp=0.5,
+                tissue_area_threshold=1,
+                seg_model="neural",
+                seg_level=1,
+            )
+
+        mock_wsi.read_region.assert_called_once()
+        mock_neural.assert_called_once()
 
     def test_seg_model_invalid_raises(self):
         """Unknown seg_model raises ValueError."""


### PR DESCRIPTION
## Summary

Fixes neural segmentation in tessellation so it no longer upsamples very coarse thumbnails into the model input resolution by default, and improves failure behavior around large neural inference requests.

## Changes

- Choose a neural-specific segmentation pyramid level near the model's 1 um/px target instead of reusing the classic 64x thumbnail level.
- Add guards for excessive neural upsampling and inference tile counts, including environment overrides for intentional expert use.
- Stream neural inference batches and avoid materializing all patches before model inference.
- Vectorize neural preprocessing instead of converting each tile through PIL/torchvision transforms.
- Reuse a neural segmenter across tessellate-extract-features batch processing.
- Respect use_gpu, gpu_device_id, and gpu_device_ids for neural segmentation in tessellate_extract_features.

## Validation

- uv run pytest tests/mussel/utils/test_neural_seg.py tests/mussel/utils/test_segment.py tests/mussel/cli/test_tessellate_extract_features.py::test_neural_segmenter_use_gpu_false_forces_cpu tests/mussel/cli/test_tessellate_extract_features.py::test_neural_segmenter_use_gpu_true_requires_cuda tests/mussel/cli/test_tessellate_extract_features.py::test_neural_segmenter_use_gpu_true_uses_cuda_when_available tests/mussel/cli/test_tessellate_extract_features.py::test_neural_segmenter_use_gpu_true_uses_requested_cuda_device tests/mussel/cli/test_tessellate_extract_features.py::test_neural_segmenter_use_gpu_true_uses_first_multi_gpu_device -q
- uv run black --check mussel/utils/neural_seg.py mussel/utils/segment.py mussel/cli/tessellate_extract_features.py mussel/cli/tessellate_extract_features_common.py tests/mussel/utils/test_neural_seg.py tests/mussel/utils/test_segment.py tests/mussel/cli/test_tessellate_extract_features.py
- uv run isort --check mussel/utils/neural_seg.py mussel/utils/segment.py mussel/cli/tessellate_extract_features.py mussel/cli/tessellate_extract_features_common.py tests/mussel/utils/test_neural_seg.py tests/mussel/utils/test_segment.py tests/mussel/cli/test_tessellate_extract_features.py