### PR TITLE
feat: expose neural tessellation controls

### DIFF
--- a/README-commands.md
+++ b/README-commands.md
@@ -209,7 +209,7 @@ Neural model loading and inference are controlled independently through
 | `neural_config.device` | `"auto"` | PyTorch device (`"auto"`, `"cpu"`, `"cuda"`, or `"cuda:N"`). |
 | `neural_config.batch_size` | `8` | Number of 512×512 inference tiles per forward pass. |
 | `neural_config.confidence_thresh` | `0.5` | Tissue probability threshold (0–1). |
-| `neural_config.max_inference_tiles` | `4096` | Fail fast if one slide would require more model tiles; set to `0` to disable. |
+| `neural_config.max_inference_tiles` | `null` (effective default `4096`) | Fail fast if one slide would require more model tiles; explicit values override `MUSSEL_NEURAL_SEG_MAX_TILES`; set to `0` to disable. |
 
 For example, cap the final HDF5 at 10,000 tiles while limiting neural inference:
 

--- a/README-commands.md
+++ b/README-commands.md
@@ -142,6 +142,9 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `seg_config.remove_penmarks` | `false` | Enable pen-mark removal (requires `artifact_remover_fn` hook). |
 | `seg_config.seg_model` | `"classic"` | Segmentation backend: `"classic"` (HSV + fixed threshold), `"otsu"` (HSV + Otsu automatic threshold), or `"neural"` (deep learning; see below). Note: the old `seg_config.use_otsu=true` flag is deprecated — use `seg_model=otsu` instead. |
 | `seg_config.slide_mpp_override` | `null` | Override the slide's native MPP; useful when metadata is missing or wrong. |
+| `seg_config.max_tiles` | `null` | Optional cap on output tiles after tissue and per-tile filtering. |
+| `seg_config.max_tiles_strategy` | `"random"` | How to select tiles when the cap is reached: seeded `"random"` or `"first"`. |
+| `seg_config.max_tiles_seed` | `42` | Seed for the random output-tile selection. |
 
 Example with 50% overlap and tissue filtering:
 ```bash
@@ -195,6 +198,25 @@ tessellate_extract_features \
     output_pt_path=948176_embed.pt \
     model_type=UNI2 \
     seg_config.seg_model=neural
+```
+
+Neural model loading and inference are controlled independently through
+`neural_config.*` (available on both commands):
+
+| Parameter | Default | Description |
+|---|---|---|
+| `neural_config.weights_path` | `null` | Local checkpoint path; otherwise download the HEST checkpoint on first use. |
+| `neural_config.device` | `"auto"` | PyTorch device (`"auto"`, `"cpu"`, `"cuda"`, or `"cuda:N"`). |
+| `neural_config.batch_size` | `8` | Number of 512×512 inference tiles per forward pass. |
+| `neural_config.confidence_thresh` | `0.5` | Tissue probability threshold (0–1). |
+| `neural_config.max_inference_tiles` | `4096` | Fail fast if one slide would require more model tiles; set to `0` to disable. |
+
+For example, cap the final HDF5 at 10,000 tiles while limiting neural inference:
+
+```bash
+tessellate slide_path=slide.svs output_h5_path=out.h5 \
+    seg_config.seg_model=neural seg_config.max_tiles=10000 \
+    neural_config.batch_size=16 neural_config.max_inference_tiles=8192
 ```
 
 ### `extract_features`
@@ -536,4 +558,3 @@ Each input file `<stem>.<ext>` produces `output_dir/<stem>.tiff`. Pass
 | `downscale_by` | `1` | Integer downsample factor (e.g. `2` converts a 40× slide to 20×). |
 | `num_workers` | `1` | Parallel workers for batch mode (`0` = all CPUs). |
 | `bigtiff` | `false` | Write BigTIFF format (required for files > ~4 GB). |
-

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ Then pass `seg_config.seg_model=neural` to `tessellate` or
 `tessellate_extract_features`. A CUDA GPU is recommended for practical
 performance but CPU inference is supported.
 
+Neural runtime controls are available under `neural_config.*` (weights path,
+device, batch size, confidence threshold, and `max_inference_tiles`). Use
+`seg_config.max_tiles` with `seg_config.max_tiles_strategy` and
+`seg_config.max_tiles_seed` to cap and reproducibly sample the final output tiles.
+
 ## Development Notes
 
 * Any commands executed using `uv run <command...>` are automatically executed in the project environment.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ Then pass `seg_config.seg_model=neural` to `tessellate` or
 performance but CPU inference is supported.
 
 Neural runtime controls are available under `neural_config.*` (weights path,
-device, batch size, confidence threshold, and `max_inference_tiles`). Use
+device, batch size, confidence threshold, and `max_inference_tiles`). An explicit
+neural device takes precedence over the workflow's `use_gpu` setting; `auto`
+uses that setting. Use
 `seg_config.max_tiles` with `seg_config.max_tiles_strategy` and
 `seg_config.max_tiles_seed` to cap and reproducibly sample the final output tiles.
 

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -25,6 +25,21 @@ from mussel.utils.segment import draw_slide_mask, save_patches_png, segment_tiss
 
 
 @dataclass
+class NeuralSegConfig:
+    """Runtime controls for the ``seg_model=neural`` backend.
+
+    These parameters configure model loading and inference, rather than the
+    tissue-mask morphology controls in :class:`SegConfig`.
+    """
+
+    weights_path: Optional[str] = None
+    device: str = "auto"
+    batch_size: int = 8
+    confidence_thresh: float = 0.5
+    max_inference_tiles: Optional[int] = 4096
+
+
+@dataclass
 class SegConfig:
     """
     patch_size (int): Tile size in pixels at the resolution set by ``mpp``.
@@ -74,6 +89,11 @@ class SegConfig:
         ``morphology_ex_kernel`` applies to all three backends.
     slide_mpp_override (float): If set, use this value (µm/px) as the slide's native MPP instead of
         reading it from slide metadata. Useful when MPP tags are missing or incorrect.
+    max_tiles (Optional[int]): Maximum number of output tiles to retain after tissue filtering.
+        ``None`` keeps all tiles.
+    max_tiles_strategy (str): Sampling strategy when ``max_tiles`` is reached: ``"random"``
+        (seeded, default) or ``"first"``.
+    max_tiles_seed (int): Random seed used by the ``"random"`` max-tile strategy.
     artifact_remover_fn: Optional callable ``(img, mask, mpp) -> mask`` where ``img`` is the RGB
         thumbnail, ``mask`` is the binary tissue mask, and ``mpp`` is the thumbnail's µm/px.
         Returns a corrected binary mask. Use :class:`~mussel.utils.artifact_removal.GrandQCArtifactRemover`
@@ -123,6 +143,9 @@ class SegConfig:
     slide_mpp_override: Optional[float] = (
         None  # If set, use this as the slide's native MPP instead of reading from metadata.
     )
+    max_tiles: Optional[int] = None
+    max_tiles_strategy: str = "random"
+    max_tiles_seed: int = 42
 
 
 @dataclass
@@ -260,6 +283,8 @@ class TessellateConfig:
     output_thumbnail_path (Optional[str]): Path to save a plain slide thumbnail (no overlay).
     thumbnail_size (tuple): Width × height in pixels for the saved thumbnail (default 1024×1024).
     seg_config (SegConfig): Segmentation and tiling parameters (see below).
+    neural_config (NeuralSegConfig): Model and inference parameters used when
+        ``seg_config.seg_model="neural"``.
     vis_config (VisConfig): Visualization appearance parameters for mask overlays (see below).
     png_config (PngConfig): Filtering parameters applied when saving PNG tiles (see below).
     num_workers (int): Number of parallel workers used when saving PNG tiles.
@@ -282,6 +307,7 @@ class TessellateConfig:
     thumbnail_size: tuple = (1024, 1024)
     num_workers: int = 4
     seg_config: SegConfig = MISSING
+    neural_config: NeuralSegConfig = field(default_factory=NeuralSegConfig)
     vis_config: VisConfig = field(default_factory=VisConfig)
     png_config: PngConfig = field(default_factory=PngConfig)
 
@@ -300,6 +326,8 @@ Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
   seg_config.mpp      Target resolution in µm/px (default 0.5 ≈ 20×; 0.25 ≈ 40×)
   seg_config.patch_size  Tile size in pixels at the target MPP (default 256)
   seg_config.seg_model   Segmentation backend: classic | otsu | neural
+  seg_config.max_tiles   Optional cap on output tiles after tissue filtering
+  neural_config.*        Neural model/runtime controls (used with seg_model=neural)
 
 Example:
   tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=biopsy
@@ -310,6 +338,7 @@ parameter_doc = f"""
 == Available Parameters ==
 {TessellateConfig.__doc__}
 seg_config: {SegConfig.__doc__}
+neural_config: {NeuralSegConfig.__doc__}
 vis_config: {VisConfig.__doc__}
 png_config: {PngConfig.__doc__}
 
@@ -458,18 +487,34 @@ def _build_neural_segmenter(
     use_gpu: Optional[bool] = None,
     gpu_device_id: Optional[int | List[int]] = None,
     gpu_device_ids: Optional[List[int]] = None,
+    neural_config: Optional[dict] = None,
 ) -> Optional[Any]:
     if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
         return None
 
     from mussel.utils.neural_seg import NeuralTissueSegmenter
 
+    neural_config = dict(neural_config or {})
+    neural_config.pop("_target_", None)
+    # Avoid changing the no-override constructor call (and let the segmenter
+    # retain its environment-based defaults) when Hydra supplied only the
+    # structured config defaults.
+    neural_defaults = vars(NeuralSegConfig())
+    neural_config = {
+        key: value
+        for key, value in neural_config.items()
+        if key not in neural_defaults or value != neural_defaults[key]
+    }
+
     if use_gpu is None:
         logger.info("Loading neural tissue segmenter.")
-        return NeuralTissueSegmenter()
+        return NeuralTissueSegmenter(**neural_config)
 
     if not use_gpu:
-        return NeuralTissueSegmenter(device="cpu")
+        # Feature extraction's use_gpu flag is authoritative for the
+        # integrated workflow, while retaining all other neural controls.
+        neural_config["device"] = "cpu"
+        return NeuralTissueSegmenter(**neural_config)
 
     import torch
 
@@ -486,10 +531,13 @@ def _build_neural_segmenter(
     )
     device = "cuda" if device_id is None else f"cuda:{device_id}"
     logger.info("Loading neural tissue segmenter.")
-    return NeuralTissueSegmenter(device=device)
+    neural_config["device"] = device
+    return NeuralTissueSegmenter(**neural_config)
 
 
-def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
+def _run_batch(
+    cfg: TessellateConfig, seg_cfg: dict, neural_config: Optional[dict] = None
+) -> None:
     if any(
         value is not None
         for value in (
@@ -505,7 +553,7 @@ def _run_batch(cfg: TessellateConfig, seg_cfg: dict) -> None:
         )
 
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
-    neural_segmenter = _build_neural_segmenter(seg_cfg)
+    neural_segmenter = _build_neural_segmenter(seg_cfg, neural_config=neural_config)
     failures: list[tuple[str, str, str, str]] = []
     items = _resolve_batch_outputs(cfg)
     logger.info("Batch tessellating %d slide(s)", len(items))
@@ -558,25 +606,35 @@ def main(
     cfg: TessellateConfig,
 ):
     """Tile a whole slide image and perform tissue segmentation."""
-    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    seg_cfg = OmegaConf.to_container(cfg.seg_config, resolve=True)
+    neural_cfg_obj = getattr(cfg, "neural_config", NeuralSegConfig())
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if OmegaConf.is_config(neural_cfg_obj)
+        else vars(neural_cfg_obj)
+    )
     if cfg.slide_paths is not None:
         if cfg.slide_path is not None or cfg.output_h5_path is not None:
             raise ValueError(
                 "Batch mode is mutually exclusive with slide_path and output_h5_path."
             )
-        _run_batch(cfg, seg_cfg)
+        _run_batch(cfg, seg_cfg, neural_config=neural_cfg)
         return
 
     if cfg.slide_path is None or cfg.output_h5_path is None:
         raise ValueError("Single-slide mode requires slide_path and output_h5_path.")
 
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    neural_segmenter = _build_neural_segmenter(
+        seg_cfg, neural_config=neural_cfg
+    )
     if values := _run_tessellation(
         slide_path=cfg.slide_path,
         slide_id=cfg.slide_id,
         output_h5_path=cfg.output_h5_path,
         seg_cfg=seg_cfg,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     ):
         polygon, grid, coords = values
     else:

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -36,7 +36,8 @@ class NeuralSegConfig:
     device: str = "auto"
     batch_size: int = 8
     confidence_thresh: float = 0.5
-    max_inference_tiles: Optional[int] = 4096
+    # None preserves the segmenter's environment fallback (4096 when unset).
+    max_inference_tiles: Optional[int] = None
 
 
 @dataclass
@@ -496,42 +497,43 @@ def _build_neural_segmenter(
 
     neural_config = dict(neural_config or {})
     neural_config.pop("_target_", None)
-    # Avoid changing the no-override constructor call (and let the segmenter
-    # retain its environment-based defaults) when Hydra supplied only the
-    # structured config defaults.
-    neural_defaults = vars(NeuralSegConfig())
-    neural_config = {
-        key: value
-        for key, value in neural_config.items()
-        if key not in neural_defaults or value != neural_defaults[key]
-    }
+    configured_device = neural_config.get("device", "auto")
+    device_is_auto = str(configured_device).strip().lower() == "auto"
 
-    if use_gpu is None:
-        logger.info("Loading neural tissue segmenter.")
-        return NeuralTissueSegmenter(**neural_config)
+    # An explicit neural device is independent from feature extraction's
+    # use_gpu setting. Only resolve GPU options when the neural device is auto.
+    if device_is_auto and use_gpu is not None:
+        if not use_gpu:
+            neural_config["device"] = "cpu"
+        else:
+            import torch
 
-    if not use_gpu:
-        # Feature extraction's use_gpu flag is authoritative for the
-        # integrated workflow, while retaining all other neural controls.
-        neural_config["device"] = "cpu"
-        return NeuralTissueSegmenter(**neural_config)
+            from mussel.utils.gpu import first_gpu_device_id, resolve_gpu_device_id
 
-    import torch
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "seg_config.seg_model='neural' requested with use_gpu=True, "
+                    "but CUDA is not available. Set use_gpu=False or "
+                    "neural_config.device=cpu to run neural segmentation on CPU."
+                )
+            device_id = first_gpu_device_id(
+                resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
+            )
+            neural_config["device"] = (
+                "cuda" if device_id is None else f"cuda:{device_id}"
+            )
+    elif not device_is_auto and str(configured_device).strip().lower().startswith(
+        "cuda"
+    ):
+        import torch
 
-    from mussel.utils.gpu import first_gpu_device_id, resolve_gpu_device_id
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                f"neural_config.device={configured_device!r} requested, "
+                "but CUDA is not available. Set neural_config.device=cpu."
+            )
 
-    if not torch.cuda.is_available():
-        raise RuntimeError(
-            "seg_config.seg_model='neural' requested with use_gpu=True, "
-            "but CUDA is not available. Set use_gpu=False to run neural "
-            "segmentation on CPU."
-        )
-    device_id = first_gpu_device_id(
-        resolve_gpu_device_id(gpu_device_id, gpu_device_ids)
-    )
-    device = "cuda" if device_id is None else f"cuda:{device_id}"
     logger.info("Loading neural tissue segmenter.")
-    neural_config["device"] = device
     return NeuralTissueSegmenter(**neural_config)
 
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -21,6 +21,7 @@ from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 # isort: off
 from mussel.cli.tessellate import (
     BiopsySegConfig,
+    NeuralSegConfig,
     PngConfig,
     ResectionSegConfig,
     SegConfig,
@@ -66,13 +67,20 @@ _is_remote_path = is_remote_path
 
 
 def _build_segmentation_runtime(cfg: "TessellateExtractFeaturesConfig"):
-    seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    seg_cfg = OmegaConf.to_container(cfg.seg_config, resolve=True)
+    neural_cfg_obj = getattr(cfg, "neural_config", NeuralSegConfig())
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if OmegaConf.is_config(neural_cfg_obj)
+        else vars(neural_cfg_obj)
+    )
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
     neural_segmenter = _build_neural_segmenter(
         seg_cfg,
         cfg.use_gpu,
         gpu_device_id=cfg.gpu_device_id,
         gpu_device_ids=cfg.gpu_device_ids,
+        neural_config=neural_cfg,
     )
     return artifact_remover_fn, neural_segmenter
 
@@ -179,6 +187,8 @@ class TessellateExtractFeaturesConfig:
 
     Segmentation & Processing Parameters:
         seg_config (SegConfig): Configuration for segmentation parameters.
+        neural_config (NeuralSegConfig): Model and inference parameters used when
+            ``seg_config.seg_model="neural"``.
         vis_config (VisConfig): Configuration for visualization parameters.
         png_config (PngConfig): Configuration for PNG saving parameters.
         num_workers (int): Number of workers for saving patches and feature extraction.
@@ -243,6 +253,7 @@ class TessellateExtractFeaturesConfig:
         True  # Save final features to .h5 files; if False, only .pt files are saved (but tile_h5 is kept for patch encoders)
     )
     seg_config: SegConfig = MISSING
+    neural_config: NeuralSegConfig = field(default_factory=NeuralSegConfig)
     vis_config: VisConfig = field(default_factory=VisConfig)
     png_config: PngConfig = field(default_factory=PngConfig)
     intermediate_h5_path: Optional[str] = None
@@ -350,6 +361,7 @@ parameter_doc = f"""
 == Available Parameters ==
 {TessellateExtractFeaturesConfig.__doc__}
 seg_config: {SegConfig.__doc__}
+neural_config: {NeuralSegConfig.__doc__}
 vis_config: {VisConfig.__doc__}
 png_config: {PngConfig.__doc__}
 

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -65,6 +65,9 @@ class NeuralTissueSegmenter:
         batch_size: Number of 512×512 patches to process per forward pass.
         confidence_thresh: Sigmoid threshold for tissue/background decision.
             Lower values → more tissue retained. Default 0.5.
+        max_inference_tiles: Maximum number of model inference tiles for one
+            slide. ``None`` uses ``MUSSEL_NEURAL_SEG_MAX_TILES`` (default 4096);
+            zero disables the guard.
     """
 
     def __init__(
@@ -75,6 +78,18 @@ class NeuralTissueSegmenter:
         confidence_thresh: float = 0.5,
         max_inference_tiles: Optional[int] = None,
     ):
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if not 0.0 <= confidence_thresh <= 1.0:
+            raise ValueError(
+                f"confidence_thresh must be in [0.0, 1.0], got {confidence_thresh}"
+            )
+        if max_inference_tiles is not None and max_inference_tiles < 0:
+            raise ValueError(
+                "max_inference_tiles must be non-negative or None, "
+                f"got {max_inference_tiles}"
+            )
+
         if device == "auto":
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
@@ -82,11 +97,14 @@ class NeuralTissueSegmenter:
 
         self.batch_size = batch_size
         self.confidence_thresh = confidence_thresh
-        self.max_inference_tiles = (
+        configured_max_tiles = (
             _get_max_inference_tiles()
             if max_inference_tiles is None
             else max_inference_tiles
         )
+        # A value of zero is a convenient explicit way to disable the guard,
+        # matching the environment-variable behavior.
+        self.max_inference_tiles = configured_max_tiles or None
         self._model = None
         self._weights_path = weights_path
         self._mean = None  # built lazily alongside the model

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -599,6 +599,9 @@ def segment_tissue(
     seg_model: str = "classic",  # "classic" (HSV + manual threshold), "otsu" (HSV + Otsu threshold), or "neural" (DeepLabV3)
     slide_mpp_override: Optional[float] = None,
     neural_segmenter=None,
+    max_tiles: Optional[int] = None,
+    max_tiles_strategy: str = "random",
+    max_tiles_seed: int = 42,
 ):
     """Segment tissue regions in a whole-slide image and generate tissue patches.
 
@@ -664,6 +667,13 @@ def segment_tissue(
             ``morphology_ex_kernel`` applies to all three modes.
         slide_mpp_override: If set, use this value (µm/px) as the slide's native MPP
             instead of reading it from slide metadata.
+        neural_segmenter: Optional preloaded neural segmenter instance. This is useful
+            for reusing model weights across slides in batch workflows.
+        max_tiles: Optional maximum number of output tiles to retain after all tissue
+            filtering. ``None`` keeps all tiles.
+        max_tiles_strategy: ``"random"`` (seeded) or ``"first"`` when ``max_tiles``
+            is smaller than the available tile count.
+        max_tiles_seed: Seed used by the random max-tile strategy.
 
     Returns:
         tuple: A 4-tuple containing:
@@ -691,6 +701,13 @@ def segment_tissue(
         if not (0.0 <= min_tissue_proportion <= 1.0):
             raise ValueError(
                 f"min_tissue_proportion must be in [0.0, 1.0], got {min_tissue_proportion}"
+            )
+        if max_tiles is not None and max_tiles <= 0:
+            raise ValueError(f"max_tiles must be positive or None, got {max_tiles}")
+        if max_tiles_strategy not in {"random", "first"}:
+            raise ValueError(
+                "max_tiles_strategy must be 'random' or 'first', "
+                f"got {max_tiles_strategy!r}"
             )
 
         if exclude_ids is None:
@@ -1006,6 +1023,27 @@ def segment_tissue(
                 f"{len(coords)} patches remaining"
             )
 
+        # Apply the output budget after all tissue and per-tile filtering so
+        # that the budget is spent only on valid tiles. Sorting the sampled
+        # indices preserves partition order for stable downstream output.
+        if max_tiles is not None and len(coords) > max_tiles:
+            if max_tiles_strategy == "random":
+                selected = np.sort(
+                    np.random.default_rng(max_tiles_seed).choice(
+                        len(coords), size=max_tiles, replace=False
+                    )
+                )
+            else:
+                selected = np.arange(max_tiles)
+            grid = [grid[i] for i in selected]
+            coords = [coords[i] for i in selected]
+            logger.info(
+                "After max_tiles=%d (%s) filter: %d patches remaining",
+                max_tiles,
+                max_tiles_strategy,
+                len(coords),
+            )
+
         attrs = {
             "seg_level": seg_level,
             "segment_threshold": segment_threshold,
@@ -1028,6 +1066,9 @@ def segment_tissue(
             "overlap": overlap,
             "min_tissue_proportion": min_tissue_proportion,
             "seg_model": seg_model,
+            "max_tiles": -1 if max_tiles is None else max_tiles,
+            "max_tiles_strategy": max_tiles_strategy,
+            "max_tiles_seed": max_tiles_seed,
         }
         if output_h5_path:
             asset_dict = {"coords": np.array(coords, dtype=np.int64)}

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -8,7 +8,7 @@ import pytest
 from omegaconf import OmegaConf
 
 import mussel.cli.tessellate
-from mussel.cli.tessellate import SegConfig, TessellateConfig
+from mussel.cli.tessellate import NeuralSegConfig, SegConfig, TessellateConfig
 
 # Dimensions of the test slide (85656 x 19917 at level 0)
 _SLIDE_WIDTH = 85656
@@ -137,6 +137,25 @@ def test_tessellate_batch_reuses_neural_segmenter(tmp_path):
         call.kwargs["neural_segmenter"] is shared_segmenter
         for call in mock_segment.call_args_list
     )
+
+
+def test_neural_segmenter_runtime_config_is_forwarded():
+    seg_cfg = {"seg_model": "neural"}
+    neural_cfg = {
+        "weights_path": "/tmp/tissue.ckpt",
+        "device": "cpu",
+        "batch_size": 16,
+        "confidence_thresh": 0.65,
+        "max_inference_tiles": 2048,
+    }
+
+    with patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter:
+        result = mussel.cli.tessellate._build_neural_segmenter(
+            seg_cfg, neural_config=neural_cfg
+        )
+
+    MockSegmenter.assert_called_once_with(**neural_cfg)
+    assert result is MockSegmenter.return_value
 
 
 def test_tessellate_batch_fails_on_first_slide_failure(tmp_path):

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -131,7 +131,7 @@ def test_tessellate_batch_reuses_neural_segmenter(tmp_path):
         ) as mock_segment:
             mussel.cli.tessellate.main(OmegaConf.create(cfg))
 
-    mock_segmenter_cls.assert_called_once_with()
+    mock_segmenter_cls.assert_called_once_with(**vars(NeuralSegConfig()))
     assert mock_segment.call_count == 2
     assert all(
         call.kwargs["neural_segmenter"] is shared_segmenter

--- a/tests/mussel/cli/test_tessellate_extract_features.py
+++ b/tests/mussel/cli/test_tessellate_extract_features.py
@@ -66,6 +66,35 @@ def test_neural_segmenter_use_gpu_false_forces_cpu():
     assert result is MockSegmenter.return_value
 
 
+def test_explicit_neural_device_overrides_use_gpu():
+    seg_cfg = {"seg_model": "neural"}
+    neural_cfg = {"device": "cpu", "batch_size": 16}
+
+    with patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter:
+        result = _build_neural_segmenter(
+            seg_cfg, use_gpu=True, neural_config=neural_cfg
+        )
+
+    MockSegmenter.assert_called_once_with(**neural_cfg)
+    assert result is MockSegmenter.return_value
+
+
+def test_explicit_neural_cuda_device_overrides_cpu_workflow():
+    seg_cfg = {"seg_model": "neural"}
+    neural_cfg = {"device": "cuda:2"}
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch("mussel.utils.neural_seg.NeuralTissueSegmenter") as MockSegmenter,
+    ):
+        result = _build_neural_segmenter(
+            seg_cfg, use_gpu=False, neural_config=neural_cfg
+        )
+
+    MockSegmenter.assert_called_once_with(**neural_cfg)
+    assert result is MockSegmenter.return_value
+
+
 def test_neural_segmenter_use_gpu_true_requires_cuda():
     seg_cfg = {"seg_model": "neural"}
 

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -127,6 +127,22 @@ class TestSegmentAllBackground:
 
 
 class TestSlideMppRescaling:
+    def test_constructor_validates_runtime_controls(self):
+        from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+        with pytest.raises(ValueError, match="batch_size"):
+            NeuralTissueSegmenter(batch_size=0)
+        with pytest.raises(ValueError, match="confidence_thresh"):
+            NeuralTissueSegmenter(confidence_thresh=1.1)
+        with pytest.raises(ValueError, match="max_inference_tiles"):
+            NeuralTissueSegmenter(max_inference_tiles=-1)
+
+    def test_zero_max_inference_tiles_disables_guard(self):
+        from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+        seg = NeuralTissueSegmenter(device="cpu", max_inference_tiles=0)
+        assert seg.max_inference_tiles is None
+
     def test_mpp_scaling_preserves_output_size(self):
         """Output mask must match original img size regardless of slide_mpp."""
         H, W = 100, 200

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -143,6 +143,17 @@ class TestSlideMppRescaling:
         seg = NeuralTissueSegmenter(device="cpu", max_inference_tiles=0)
         assert seg.max_inference_tiles is None
 
+    def test_default_max_inference_tiles_uses_environment_fallback(self, monkeypatch):
+        from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+        monkeypatch.setenv("MUSSEL_NEURAL_SEG_MAX_TILES", "17")
+        seg = NeuralTissueSegmenter(device="cpu")
+        assert seg.max_inference_tiles == 17
+
+        monkeypatch.delenv("MUSSEL_NEURAL_SEG_MAX_TILES")
+        seg = NeuralTissueSegmenter(device="cpu")
+        assert seg.max_inference_tiles == 4096
+
     def test_mpp_scaling_preserves_output_size(self):
         """Output mask must match original img size regardless of slide_mpp."""
         H, W = 100, 200

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -873,6 +873,7 @@ class TestSegmentTissueOverlap:
                     "/fake/slide.svs", seg_level=0, patch_size=256, overlap=256
                 )
 
+
     def test_overlap_greater_than_patch_size_raises(self):
         """overlap > patch_size must raise ValueError."""
         from mussel.utils.segment import segment_tissue
@@ -904,6 +905,53 @@ class TestSegmentTissueOverlap:
                 segment_tissue(
                     "/fake/slide.svs", seg_level=0, patch_size=256, overlap=-50
                 )
+
+
+class TestSegmentTissueMaxTiles:
+    def test_max_tiles_first_caps_output_and_records_attrs(self):
+        result = _run_segment_with_mocks(
+            _make_mock_wsi_with_real_tissue(),
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            tissue_area_threshold=1,
+            max_tiles=5,
+            max_tiles_strategy="first",
+        )
+
+        assert result is not None
+        _, _, coords, attrs = result
+        assert len(coords) == 5
+        assert attrs["max_tiles"] == 5
+        assert attrs["max_tiles_strategy"] == "first"
+
+    def test_max_tiles_random_selection_is_seeded(self):
+        kwargs = dict(
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            tissue_area_threshold=1,
+            max_tiles=5,
+            max_tiles_strategy="random",
+            max_tiles_seed=7,
+        )
+        result_a = _run_segment_with_mocks(
+            _make_mock_wsi_with_real_tissue(), **kwargs
+        )
+        result_b = _run_segment_with_mocks(
+            _make_mock_wsi_with_real_tissue(), **kwargs
+        )
+
+        assert result_a is not None and result_b is not None
+        assert result_a[2] == result_b[2]
+
+    def test_max_tiles_validates_positive_limit_and_strategy(self):
+        with pytest.raises(ValueError, match="max_tiles must be positive"):
+            _run_segment_with_mocks(_make_mock_wsi_with_tissue(), max_tiles=0)
+        with pytest.raises(ValueError, match="max_tiles_strategy"):
+            _run_segment_with_mocks(
+                _make_mock_wsi_with_tissue(), max_tiles_strategy="weighted"
+            )
 
 
 class TestSegmentTissueMinTissueProportion:


### PR DESCRIPTION
## Summary

- expose neural segmentation runtime controls through neural_config.* for tessellate and tessellate_extract_features
- add output tile caps with seeded random/first selection via seg_config.max_tiles
- validate neural runtime settings and persist tile-cap metadata in HDF5 outputs
- document the new CLI controls

## Validation

- 118 focused tests passed (6 integration/slow tests deselected)
- verified both CLI help screens expose the new controls