### PR TITLE
Add fast stain-oriented neural tessellation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Changes
+
+<!-- Bullet list of key changes -->
+-
+
+## Testing
+
+<!-- How was this tested? Unit tests added/run? Manual verification? -->
+- [ ] Tests added / updated
+- [ ] `uv run pytest tests` passes
+
+## Notes
+
+<!-- Anything reviewers should know (breaking changes, follow-up work, etc.) -->

--- a/README-commands.md
+++ b/README-commands.md
@@ -103,6 +103,7 @@ specimen type. Individual parameters can still be overridden after the preset:
 ```bash
 tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=biopsy
 tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config.mpp=0.25
+tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=stain
 ```
 
 | Preset | Best for | Key differences from `default` | With `seg_model=neural` |
@@ -111,6 +112,7 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `biopsy` | Needle-core / punch biopsies | Lower area thresholds (`tissue_area_threshold=1`, `hole_area_threshold=1`) to keep small tissue cores; fewer holes (`max_num_holes=2`). | Area thresholds and `max_num_holes` still apply; `segment_threshold`/`median_blur_ksize` are ignored with a warning. |
 | `resection` | Surgical resection specimens | Stronger morphological closing (`morphology_ex_kernel=4`) to bridge gaps in large sections; same area thresholds as `default`. | Only `morphology_ex_kernel=4` has effect; `segment_threshold`/`median_blur_ksize` are ignored with a warning. Consider `default seg_config.seg_model=neural seg_config.morphology_ex_kernel=4` to avoid the warning. |
 | `tcga` | TCGA whole-slide images | Lower `segment_threshold=8` to capture pale/faded tissue; stronger closing (`morphology_ex_kernel=4`); reduced area thresholds. | `segment_threshold` is ignored with a warning (`median_blur_ksize=7` matches the default so no second warning); `morphology_ex_kernel=4` and area thresholds still apply. |
+| `stain` | Fast H&E/IHC stain classification | Neural validation, 32-tile cap, 75% minimum tissue fraction, small-region retention, and bounded candidate sampling (up to 256 candidates). | Uses the bounded neural path; it does not build a full-slide mask. |
 
 #### Segmentation and patching options
 
@@ -123,6 +125,8 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `seg_config.max_tiles` | `null` | Optional maximum number of output tiles after tissue filtering. `null` keeps all tiles. |
 | `seg_config.max_tiles_strategy` | `random` | Selection strategy when `max_tiles` is reached: seeded `random` or `first`. |
 | `seg_config.max_tiles_seed` | `42` | Seed for the random output-tile cap. |
+| `seg_config.selection_mode` | `full_mask` | `full_mask` segments the complete slide; `bounded_neural` proposes candidates cheaply and neural-validates only a bounded set. |
+| `seg_config.max_candidate_tiles` | `null` | Maximum neural candidates in `bounded_neural` mode; the `stain` preset sets this to `256`. |
 | `seg_config.tissue_area_threshold` | `100` | Pre-tile filter: minimum size of a tissue **region** (contour), in number of tiles. Regions smaller than this are discarded as debris before tiling begins. Default 100 ≈ a ~3.2 mm² blob at 256 px / 0.5 µm/px. Set to `1` to keep all regions (recommended for biopsies). |
 | `seg_config.hole_area_threshold` | `16` | Minimum size of a hole inside a tissue region, in number of tiles. Holes smaller than this are filled (treated as tissue). |
 | `seg_config.remove_artifacts` | `false` | Enable artifact removal (requires `artifact_remover_fn` hook). |
@@ -138,6 +142,22 @@ tessellate \
     seg_config.overlap=128 \
     seg_config.min_tissue_proportion=0.5
 ```
+
+For stain classification, use the speed-oriented preset:
+
+```bash
+tessellate_extract_features \
+    slide_path=slide.svs \
+    output_h5_path=slide.features.h5 \
+    output_pt_path=slide.features.pt \
+    model_type=HOPTIMUS0 \
+    seg_config=stain
+```
+
+The preset stops after 32 tiles with at least 75% neural tissue, or after 256
+candidate checks. If fewer than 32 tiles qualify, it returns the qualifying
+tiles without relaxing the cutoff. In bounded mode, mask output represents
+the accepted tile footprints rather than a complete slide tissue contour.
 
 #### Neural tissue segmentation (`seg_model="neural"`)
 

--- a/README-commands.md
+++ b/README-commands.md
@@ -120,6 +120,9 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `seg_config.patch_size` | `256` | Tile size in pixels at the target MPP. |
 | `seg_config.overlap` | `0` | Patch overlap in absolute pixels. Sets `step_size = patch_size - overlap`. |
 | `seg_config.min_tissue_proportion` | `0.0` | Per-tile filter: discard tiles where the fraction of tissue pixels is below this value (0.0–1.0). Applied after tiling; `0.1` discards mostly-background edge tiles. |
+| `seg_config.max_tiles` | `null` | Optional maximum number of output tiles after tissue filtering. `null` keeps all tiles. |
+| `seg_config.max_tiles_strategy` | `random` | Selection strategy when `max_tiles` is reached: seeded `random` or `first`. |
+| `seg_config.max_tiles_seed` | `42` | Seed for the random output-tile cap. |
 | `seg_config.tissue_area_threshold` | `100` | Pre-tile filter: minimum size of a tissue **region** (contour), in number of tiles. Regions smaller than this are discarded as debris before tiling begins. Default 100 ≈ a ~3.2 mm² blob at 256 px / 0.5 µm/px. Set to `1` to keep all regions (recommended for biopsies). |
 | `seg_config.hole_area_threshold` | `16` | Minimum size of a hole inside a tissue region, in number of tiles. Holes smaller than this are filled (treated as tissue). |
 | `seg_config.remove_artifacts` | `false` | Enable artifact removal (requires `artifact_remover_fn` hook). |
@@ -159,6 +162,16 @@ The neural segmenter operates at 1 µm/px resolution (≈10×); images are auto-
 before inference and the mask is rescaled back to the slide's native resolution. A CUDA
 GPU is recommended for practical performance but CPU inference is supported.
 
+Neural runtime controls are available through `neural_config.*`:
+
+| Option | Default | Description |
+|---|---:|---|
+| `neural_config.weights_path` | `null` | Local checkpoint path; `null` downloads the HEST checkpoint automatically. |
+| `neural_config.device` | `auto` | PyTorch device (`auto`, `cpu`, `cuda`, or `cuda:<id>`). |
+| `neural_config.batch_size` | `8` | Number of 512×512 inference tiles per forward pass. |
+| `neural_config.confidence_thresh` | `0.5` | Tissue probability threshold. |
+| `neural_config.max_inference_tiles` | `4096` | Safety cap on neural inference tiles after rescaling. Set `0` to disable. |
+
 No extra packages are required — neural segmentation works with any `torch-gpu` or
 `torch-cpu` install:
 
@@ -172,6 +185,16 @@ tessellate \
     slide_path=tests/testdata/948176.svs \
     output_h5_path=948176_coord.h5 \
     seg_config.seg_model=neural
+
+# Example: use a local checkpoint, smaller inference batches, and cap output tiles
+tessellate \
+    slide_path=tests/testdata/948176.svs \
+    output_h5_path=948176_coord.h5 \
+    seg_config.seg_model=neural \
+    neural_config.weights_path=/models/deeplabv3_seg_v4.ckpt \
+    neural_config.batch_size=4 \
+    neural_config.max_inference_tiles=2000 \
+    seg_config.max_tiles=10000
 
 tessellate_extract_features \
     slide_path=tests/testdata/948176.svs \
@@ -337,7 +360,8 @@ tessellate_extract_features \
 
 Supported WSI extensions discovered during directory scan: `.svs`, `.ndpi`, `.tiff`, `.tif`, `.scn`, `.mrxs`, `.vms`, `.vmu`, `.bif`, `.qptiff`, `.czi`.
 All `seg_config.*` options (including `seg_model=neural` and `slide_mpp_override`) are
-also available on this command; see the [`tessellate` section](#tessellate) above.
+also available on this command, as are the `neural_config.*` runtime controls; see the
+[`tessellate` section](#tessellate) above.
 
 ### `annotate`
 
@@ -520,5 +544,3 @@ Each input file `<stem>.<ext>` produces `output_dir/<stem>.tiff`. Pass
 | `downscale_by` | `1` | Integer downsample factor (e.g. `2` converts a 40× slide to 20×). |
 | `num_workers` | `1` | Parallel workers for batch mode (`0` = all CPUs). |
 | `bigtiff` | `false` | Write BigTIFF format (required for files > ~4 GB). |
-
-

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ Then pass `seg_config.seg_model=neural` to `tessellate` or
 `tessellate_extract_features`. A CUDA GPU is recommended for practical
 performance but CPU inference is supported.
 
+For stain classification, use `seg_config=stain`. This speed-oriented preset
+uses bounded neural validation, keeps up to 32 tiles with at least 75% tissue,
+and checks at most 256 candidates. It avoids full-slide neural inference; when
+fewer than 32 candidates qualify, it returns the qualifying tiles without
+relaxing the tissue cutoff.
+
 Neural model controls use Hydra overrides such as
 `neural_config.device=cpu`, `neural_config.batch_size=4`,
 `neural_config.confidence_thresh=0.4`, and

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ The tools currently available from Mussel are,
 These are described, with examples, in the accompanying document, [README-commands.md](README-commands.md)
 
 
+## Nextflow pipeline
+
+For running Mussel at scale on a compute cluster, see
+**[mussel-nf](https://github.com/pathology-data-mining/mussel-nf)** — a Nextflow
+pipeline that wraps the Mussel CLI tools and handles job scheduling, parallelism,
+and output management across large slide cohorts.
+
 ## License
 This code is made available under the GPLv3 License and is available for non-commercial academic purposes.
 Forked from CLAM, © [Mahmood Lab](http://www.mahmoodlab.org).

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ Then pass `seg_config.seg_model=neural` to `tessellate` or
 `tessellate_extract_features`. A CUDA GPU is recommended for practical
 performance but CPU inference is supported.
 
+Neural model controls use Hydra overrides such as
+`neural_config.device=cpu`, `neural_config.batch_size=4`,
+`neural_config.confidence_thresh=0.4`, and
+`neural_config.max_inference_tiles=4096` (set to `0` to disable the safety
+guard). To limit the final tessellation output independently, use
+`seg_config.max_tiles=10000`.
+
 ## Development Notes
 
 * Any commands executed using `uv run <command...>` are automatically executed in the project environment.

--- a/mussel/cli/extract_features.py
+++ b/mussel/cli/extract_features.py
@@ -311,6 +311,18 @@ def _main_batch(cfg: ExtractFeaturesConfig):
             gpu_device_ids=cfg.gpu_device_ids,
             slide_batch_size=cfg.slide_batch_size,
         )
+
+        # Defense-in-depth: verify at least one output file was created.
+        # aggregate_slide_features_batch already raises when ALL slides fail,
+        # but guard here too in case of unexpected silent failures.
+        missing = [p for p in output_pt_paths if not os.path.isfile(p)]
+        if len(missing) == len(output_pt_paths):
+            raise RuntimeError(
+                f"extract_features produced no output files: all {len(output_pt_paths)} "
+                ".features.pt files are missing after slide-level aggregation. "
+                "All slides may have failed (e.g. CUDA out of memory in TITAN). "
+                "Check logs above for per-slide errors."
+            )
     else:
         # Single-step: extract directly to final output (no aggregation)
         extract_patch_features_batch(

--- a/mussel/cli/filter_tessellate.py
+++ b/mussel/cli/filter_tessellate.py
@@ -16,7 +16,7 @@ from omegaconf import MISSING, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig,
+                                   StainSegConfig, TcgaSegConfig, VisConfig,
                                    _build_artifact_remover)
 from mussel.cli.tessellate_extract_features_common import _build_grid_polygons
 from mussel.models import ModelType, get_default_patch_size
@@ -132,6 +132,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(name="filter_tessellate_config", node=FilterTessellateConfig)
 
 

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -26,6 +26,22 @@ from mussel.utils.segment import (draw_slide_mask, save_patches_png,
 
 
 @dataclass
+class NeuralSegConfig:
+    """Runtime controls for the ``seg_model=neural`` backend.
+
+    These options are kept separate from the classic segmentation parameters
+    because they configure model loading and inference rather than tissue-mask
+    morphology.
+    """
+
+    weights_path: Optional[str] = None
+    device: str = "auto"
+    batch_size: int = 8
+    confidence_thresh: float = 0.5
+    max_inference_tiles: Optional[int] = 4096
+
+
+@dataclass
 class SegConfig:
     """
     patch_size (int): Tile size in pixels at the resolution set by ``mpp``.
@@ -75,6 +91,11 @@ class SegConfig:
         ``morphology_ex_kernel`` applies to all three backends.
     slide_mpp_override (float): If set, use this value (µm/px) as the slide's native MPP instead of
         reading it from slide metadata. Useful when MPP tags are missing or incorrect.
+    max_tiles (Optional[int]): Maximum number of output tiles to retain after tissue filtering.
+        ``None`` keeps all tiles.
+    max_tiles_strategy (str): Sampling strategy when ``max_tiles`` is reached: ``"random"``
+        (seeded, default) or ``"first"``.
+    max_tiles_seed (int): Random seed used by the ``"random"`` max-tile strategy.
     artifact_remover_fn: Optional callable ``(img, mask, mpp) -> mask`` where ``img`` is the RGB
         thumbnail, ``mask`` is the binary tissue mask, and ``mpp`` is the thumbnail's µm/px.
         Returns a corrected binary mask. Use :class:`~mussel.utils.artifact_removal.GrandQCArtifactRemover`
@@ -126,6 +147,9 @@ class SegConfig:
     slide_mpp_override: Optional[float] = (
         None  # If set, use this as the slide's native MPP instead of reading from metadata.
     )
+    max_tiles: Optional[int] = None
+    max_tiles_strategy: str = "random"
+    max_tiles_seed: int = 42
 
 
 @dataclass
@@ -249,6 +273,8 @@ class TessellateConfig:
     output_thumbnail_path (Optional[str]): Path to save a plain slide thumbnail (no overlay).
     thumbnail_size (tuple): Width × height in pixels for the saved thumbnail (default 1024×1024).
     seg_config (SegConfig): Segmentation and tiling parameters (see below).
+    neural_config (NeuralSegConfig): Model and inference parameters used when
+        ``seg_config.seg_model="neural"``.
     vis_config (VisConfig): Visualization appearance parameters for mask overlays (see below).
     png_config (PngConfig): Filtering parameters applied when saving PNG tiles (see below).
     num_workers (int): Number of parallel workers used when saving PNG tiles.
@@ -265,6 +291,7 @@ class TessellateConfig:
     thumbnail_size: tuple = (1024, 1024)
     num_workers: int = 4
     seg_config: SegConfig = MISSING
+    neural_config: NeuralSegConfig = field(default_factory=NeuralSegConfig)
     vis_config: VisConfig = field(default_factory=VisConfig)
     png_config: PngConfig = field(default_factory=PngConfig)
 
@@ -282,6 +309,8 @@ Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
   seg_config.mpp      Target resolution in µm/px (default 0.5 ≈ 20×; 0.25 ≈ 40×)
   seg_config.patch_size  Tile size in pixels at the target MPP (default 256)
   seg_config.seg_model   Segmentation backend: classic | otsu | neural
+  seg_config.max_tiles   Optional cap on output tiles after tissue filtering
+  neural_config.*        Neural model/runtime controls (used with seg_model=neural)
 
 Example:
   tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=biopsy
@@ -291,6 +320,7 @@ parameter_doc = f"""
 == Available Parameters ==
 {TessellateConfig.__doc__}
 seg_config: {SegConfig.__doc__}
+neural_config: {NeuralSegConfig.__doc__}
 vis_config: {VisConfig.__doc__}
 png_config: {PngConfig.__doc__}
 
@@ -358,6 +388,12 @@ def main(
 ):
     """Tile a whole slide image and perform tissue segmentation."""
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    neural_cfg_obj = getattr(cfg, "neural_config", NeuralSegConfig())
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if OmegaConf.is_config(neural_cfg_obj)
+        else vars(neural_cfg_obj)
+    )
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
     # Strip config-only keys that are not segment_tissue() parameters.
     seg_cfg.pop("artifact_exclude_classes", None)
@@ -366,6 +402,7 @@ def main(
         slide_id=cfg.slide_id,
         output_h5_path=cfg.output_h5_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_config=neural_cfg,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -96,6 +96,10 @@ class SegConfig:
     max_tiles_strategy (str): Sampling strategy when ``max_tiles`` is reached: ``"random"``
         (seeded, default) or ``"first"``.
     max_tiles_seed (int): Random seed used by the ``"random"`` max-tile strategy.
+    selection_mode (str): Tile selection backend: ``"full_mask"`` (default) or
+        ``"bounded_neural"`` for fast neural validation of a bounded candidate set.
+    max_candidate_tiles (Optional[int]): Candidate budget for ``bounded_neural``
+        selection. Defaults to 256 in that mode.
     artifact_remover_fn: Optional callable ``(img, mask, mpp) -> mask`` where ``img`` is the RGB
         thumbnail, ``mask`` is the binary tissue mask, and ``mpp`` is the thumbnail's µm/px.
         Returns a corrected binary mask. Use :class:`~mussel.utils.artifact_removal.GrandQCArtifactRemover`
@@ -150,6 +154,25 @@ class SegConfig:
     max_tiles: Optional[int] = None
     max_tiles_strategy: str = "random"
     max_tiles_seed: int = 42
+    selection_mode: str = "full_mask"
+    max_candidate_tiles: Optional[int] = None
+
+
+@dataclass
+class StainSegConfig(SegConfig):
+    """Fast, tissue-rich preset for stain classification.
+
+    The preset uses neural segmentation to validate at least 75% tissue per
+    output tile, retains small tissue regions, and stops after 32 accepted
+    tiles or 256 neural candidate evaluations.
+    """
+
+    tissue_area_threshold: int = 1
+    min_tissue_proportion: float = 0.75
+    seg_model: str = "neural"
+    max_tiles: Optional[int] = 32
+    selection_mode: str = "bounded_neural"
+    max_candidate_tiles: Optional[int] = 256
 
 
 @dataclass
@@ -305,7 +328,7 @@ extract_features and tessellate_extract_features.
 Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
   slide_path          Path to the slide file (required)
   output_h5_path      Path for the output HDF5 file (required)
-  seg_config          Preset segmentation profile: default | biopsy | resection | tcga
+  seg_config          Preset segmentation profile: default | biopsy | resection | tcga | stain
   seg_config.mpp      Target resolution in µm/px (default 0.5 ≈ 20×; 0.25 ≈ 40×)
   seg_config.patch_size  Tile size in pixels at the target MPP (default 256)
   seg_config.seg_model   Segmentation backend: classic | otsu | neural
@@ -337,6 +360,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(name="tessellate_config", node=TessellateConfig)
 
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -19,7 +19,7 @@ from hydra.conf import HelpConf, HydraConf
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
-from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
+from mussel.cli.tessellate import (BiopsySegConfig, NeuralSegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
                                    TcgaSegConfig, VisConfig,
                                    _build_artifact_remover)
@@ -146,6 +146,8 @@ class TessellateExtractFeaturesConfig:
 
     Segmentation & Processing Parameters:
         seg_config (SegConfig): Configuration for segmentation parameters.
+        neural_config (NeuralSegConfig): Neural model/runtime controls used
+            when ``seg_config.seg_model="neural"``.
         vis_config (VisConfig): Configuration for visualization parameters.
         png_config (PngConfig): Configuration for PNG saving parameters.
         num_workers (int): Number of workers for saving patches and feature extraction.
@@ -208,6 +210,7 @@ class TessellateExtractFeaturesConfig:
         True  # Save final features to .h5 files; if False, only .pt files are saved (but tile_h5 is kept for patch encoders)
     )
     seg_config: SegConfig = MISSING
+    neural_config: NeuralSegConfig = field(default_factory=NeuralSegConfig)
     vis_config: VisConfig = field(default_factory=VisConfig)
     png_config: PngConfig = field(default_factory=PngConfig)
     intermediate_h5_path: Optional[str] = None
@@ -311,6 +314,7 @@ parameter_doc = f"""
 == Available Parameters ==
 {TessellateExtractFeaturesConfig.__doc__}
 seg_config: {SegConfig.__doc__}
+neural_config: {NeuralSegConfig.__doc__}
 vis_config: {VisConfig.__doc__}
 png_config: {PngConfig.__doc__}
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -21,7 +21,7 @@ from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, NeuralSegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig,
+                                   StainSegConfig, TcgaSegConfig, VisConfig,
                                    _build_artifact_remover)
 from mussel.cli.tessellate_extract_features_common import (
     create_visualizations, process_slide_tessellation_and_filtering,
@@ -64,6 +64,31 @@ def _resolve_precision(cfg: "TessellateExtractFeaturesConfig", model_type) -> st
             return cfg.model_embedding_precision[key]
     return cfg.embedding_precision
 _safe_path_join = safe_path_join
+
+
+def _build_batch_neural_segmenter(cfg):
+    """Build one neural segmenter for all slides in a tessellation batch."""
+    seg_cfg = OmegaConf.to_container(cfg.seg_config, resolve=True)
+    if str(seg_cfg.get("seg_model", "classic")).strip().lower() != "neural":
+        return None
+
+    from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+    neural_cfg_obj = getattr(cfg, "neural_config", None)
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if neural_cfg_obj is not None
+        else {}
+    )
+    if not isinstance(neural_cfg, dict):
+        neural_cfg = {}
+    if (
+        neural_cfg.get("device", "auto") == "auto"
+        and getattr(cfg, "use_gpu", None) is False
+    ):
+        neural_cfg["device"] = "cpu"
+    logger.info("Loading one reusable neural tissue segmenter for the batch")
+    return NeuralTissueSegmenter(**neural_cfg)
 
 
 defaults = ["_self_", {"seg_config": "default"}]
@@ -331,6 +356,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(
     name="tessellate_extract_features_config", node=TessellateExtractFeaturesConfig
 )
@@ -756,6 +782,7 @@ def _main_batch(
     # Instantiate artifact remover once per batch so model weights are loaded
     # only once rather than once per slide.
     artifact_remover_fn = _build_artifact_remover(OmegaConf.to_container(cfg.seg_config))
+    neural_segmenter = _build_batch_neural_segmenter(cfg)
 
     slide_results = []
     for i, (slide_path, slide_id) in enumerate(zip(cfg.slide_paths, slide_ids)):
@@ -782,6 +809,7 @@ def _main_batch(
                 skip_second_extraction=skip_second_extraction,
                 output_mask_path=output_mask_path,
                 artifact_remover_fn=artifact_remover_fn,
+                neural_segmenter=neural_segmenter,
             )
 
             if result is None:

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -33,6 +33,7 @@ def _tessellate_and_filter(
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Tessellate a slide and optionally extract/filter features for tile selection.
 
@@ -56,6 +57,8 @@ def _tessellate_and_filter(
             slides (weights are loaded only once).  When ``None`` a new instance is
             created from ``cfg.seg_config`` flags, which incurs a model-weight
             download on first use for every slide.
+        neural_segmenter: Optional preloaded neural segmenter to reuse across
+            slides in batch mode.
 
     Returns:
         ``None`` on tessellation failure; otherwise a dict with:
@@ -108,6 +111,7 @@ def _tessellate_and_filter(
         output_h5_path=tessellate_h5_path,
         artifact_remover_fn=artifact_remover_fn,
         neural_config=neural_cfg,
+        neural_segmenter=neural_segmenter,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values
@@ -228,6 +232,7 @@ def process_slide_tessellation_and_filtering(
     two_step_mode: bool = False,
     slide_model_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Process a single slide through tessellation, optional filtering, and feature extraction.
 
@@ -250,6 +255,7 @@ def process_slide_tessellation_and_filtering(
         slide_model_path: Path to slide encoder model weights.
         artifact_remover_fn: Pre-instantiated artifact remover to reuse across slides.
             See :func:`_tessellate_and_filter` for details.
+        neural_segmenter: Optional preloaded neural segmenter to reuse across slides.
 
     Returns:
         ``None`` if processing failed (tessellation error); otherwise a dict with
@@ -268,6 +274,7 @@ def process_slide_tessellation_and_filtering(
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     )
     if result is None:
         return None
@@ -366,6 +373,7 @@ def process_slide_tessellation_only(
     skip_second_extraction: bool,
     output_mask_path: Optional[str] = None,
     artifact_remover_fn: Optional[GrandQCArtifactRemover] = None,
+    neural_segmenter=None,
 ) -> Optional[dict]:
     """Process a slide through tessellation and optional filtering (no feature extraction).
 
@@ -384,6 +392,7 @@ def process_slide_tessellation_only(
         output_mask_path: Optional path to save mask visualization.
         artifact_remover_fn: Pre-instantiated artifact remover to reuse across slides.
             See :func:`_tessellate_and_filter` for details.
+        neural_segmenter: Optional preloaded neural segmenter to reuse across slides.
 
     Returns:
         Dict with paths and coordinates for batch feature extraction, or ``None`` on failure.
@@ -400,6 +409,7 @@ def process_slide_tessellation_only(
         skip_second_extraction=skip_second_extraction,
         output_mask_path=output_mask_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
     )
     if result is None:
         return None

--- a/mussel/cli/tessellate_extract_features_common.py
+++ b/mussel/cli/tessellate_extract_features_common.py
@@ -81,6 +81,20 @@ def _tessellate_and_filter(
         )
 
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
+    neural_cfg_obj = getattr(cfg, "neural_config", None)
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if neural_cfg_obj is not None
+        else None
+    )
+    # In the integrated CLI, ``use_gpu=False`` should also force neural
+    # segmentation onto CPU unless the caller explicitly selected a device.
+    if (
+        isinstance(neural_cfg, dict)
+        and neural_cfg.get("device", "auto") == "auto"
+        and getattr(cfg, "use_gpu", None) is False
+    ):
+        neural_cfg["device"] = "cpu"
 
     if artifact_remover_fn is None:
         artifact_remover_fn = _build_artifact_remover(seg_cfg)
@@ -93,6 +107,7 @@ def _tessellate_and_filter(
         slide_id=slide_id,
         output_h5_path=tessellate_h5_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_config=neural_cfg,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values

--- a/mussel/utils/feature_extract.py
+++ b/mussel/utils/feature_extract.py
@@ -1451,11 +1451,15 @@ def aggregate_slide_features_batch(
 
         if failed_slides:
             logger.warning(f"\n=== Batch Processing Summary ===")
-            logger.warning(
-                f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-            )
+            logger.warning(f"Successfully processed: {len(successful_slides)}/{num_slides} slides")
             logger.warning(f"Failed: {len(failed_slides)} slides")
             logger.warning(f"Failed slides: {', '.join(failed_slides)}")
+            if len(failed_slides) == num_slides:
+                raise RuntimeError(
+                    f"All {num_slides} slide(s) failed during {aggregation_method!r} aggregation. "
+                    f"Failed: {', '.join(failed_slides)}. "
+                    "Check logs above for per-slide errors."
+                )
         else:
             logger.info(f"\n=== All {num_slides} slides processed successfully ===")
 
@@ -1676,13 +1680,17 @@ def aggregate_slide_features_batch(
 
     if failed_slides:
         logger.warning(f"\n=== Batch Processing Summary ===")
-        logger.warning(
-            f"Successfully processed: {len(successful_slides)}/{num_slides} slides"
-        )
         logger.warning(f"Failed: {len(failed_slides)} slides")
         logger.warning(f"Failed slides: {', '.join(failed_slides)}")
     else:
         logger.info(f"\n=== All {num_slides} slides processed successfully ===")
+
+    if len(failed_slides) == num_slides:
+        raise RuntimeError(
+            f"All {num_slides} slide(s) failed during 'model' aggregation "
+            f"(model={model_type}). Failed: {', '.join(failed_slides)}. "
+            "Check logs above for per-slide errors (e.g. CUDA out of memory)."
+        )
 
     logger.info(f"Batch aggregation complete")
     return output_h5_paths, output_pt_paths

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -162,6 +162,107 @@ class NeuralTissueSegmenter:
 
         return (full_mask * 255).astype(np.uint8)
 
+    def segment_patches(
+        self, images: list[np.ndarray], slide_mpp: float = 1.0
+    ) -> list[np.ndarray]:
+        """Segment a bounded collection of image patches in shared batches.
+
+        This is the fast-path API used by stain classification.  Unlike
+        :meth:`segment`, it never constructs a full-slide mask: each input is
+        resized to the model resolution, tiled into model windows, and
+        inferred alongside the other inputs. The returned masks have the same
+        height and width as their corresponding inputs.
+        """
+        if not images:
+            return []
+        if slide_mpp <= 0:
+            raise ValueError(f"slide_mpp must be positive, got {slide_mpp}")
+
+        self._ensure_model_loaded()
+        patch_size = _INPUT_SIZE
+        prepared: list[tuple[np.ndarray, tuple[int, int]]] = []
+        for image in images:
+            image = np.asarray(image)
+            if image.ndim != 3 or image.shape[2] < 3:
+                raise ValueError(
+                    "Each neural segmentation patch must have shape (H, W, 3+)"
+                )
+            image = image[:, :, :3].astype(np.uint8, copy=False)
+            height, width = image.shape[:2]
+            scale = slide_mpp / _TARGET_MPP
+            target_height = max(1, int(round(height * scale)))
+            target_width = max(1, int(round(width * scale)))
+            if (target_height, target_width) != (height, width):
+                image = cv2.resize(
+                    image,
+                    (target_width, target_height),
+                    interpolation=cv2.INTER_CUBIC,
+                )
+            prepared.append((image, (height, width)))
+
+        # Flatten each input into model-sized windows while retaining the
+        # originating image and window coordinates.  Batching across inputs is
+        # important here: bounded stain selection usually supplies one window
+        # per candidate context, so a single forward pass can validate many
+        # candidates at once.  Tiling also keeps this API correct if a caller
+        # supplies a context larger than one model window.
+        tile_records: list[tuple[int, int, int, int, int]] = []
+        tiles: list[np.ndarray] = []
+        output_masks = []
+        for image_index, (image, _) in enumerate(prepared):
+            target_height, target_width = image.shape[:2]
+            output_masks.append(
+                np.zeros((target_height, target_width), dtype=np.uint8)
+            )
+            for y in range(0, target_height, patch_size):
+                for x in range(0, target_width, patch_size):
+                    y1 = min(y + patch_size, target_height)
+                    x1 = min(x + patch_size, target_width)
+                    crop = image[y:y1, x:x1]
+                    if crop.shape[:2] != (patch_size, patch_size):
+                        padded = np.full(
+                            (patch_size, patch_size, 3), 255, dtype=np.uint8
+                        )
+                        padded[: crop.shape[0], : crop.shape[1]] = crop
+                        crop = padded
+                    tiles.append(crop)
+                    tile_records.append((image_index, x, y, x1, y1))
+
+        use_fp16 = self.device.type == "cuda"
+        dtype = torch.float16 if use_fp16 else torch.float32
+        for batch_start in range(0, len(tiles), self.batch_size):
+            batch = tiles[batch_start : batch_start + self.batch_size]
+            tensors = [self._transform(Image.fromarray(tile)) for tile in batch]
+
+            batch_tensor = torch.stack(tensors).to(self.device, dtype=dtype)
+            with torch.no_grad():
+                logits = self._model(batch_tensor)["out"]
+                probs = F.softmax(logits.float(), dim=1)
+                predictions = (
+                    probs[:, 1] > self.confidence_thresh
+                ).to(torch.uint8).cpu().numpy()
+
+            for prediction, record in zip(
+                predictions, tile_records[batch_start : batch_start + len(batch)]
+            ):
+                image_index, x, y, x1, y1 = record
+                output_masks[image_index][y:y1, x:x1] = prediction[
+                    : y1 - y, : x1 - x
+                ]
+
+        masks: list[np.ndarray] = []
+        for output_mask, (_, (original_height, original_width)) in zip(
+            output_masks, prepared
+        ):
+            if output_mask.shape != (original_height, original_width):
+                output_mask = cv2.resize(
+                    output_mask,
+                    (original_width, original_height),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+            masks.append((output_mask * 255).astype(np.uint8))
+        return masks
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -67,6 +67,10 @@ class NeuralTissueSegmenter:
         batch_size: Number of 512×512 patches to process per forward pass.
         confidence_thresh: Sigmoid threshold for tissue/background decision.
             Lower values → more tissue retained. Default 0.5.
+        max_inference_tiles: Maximum number of 512×512 tiles used to build the
+            neural mask after rescaling to the model resolution. ``None`` or
+            ``0`` disables the guard. This prevents an accidental full-slide
+            inference from exhausting memory or running indefinitely.
     """
 
     def __init__(
@@ -75,14 +79,28 @@ class NeuralTissueSegmenter:
         device: str = "auto",
         batch_size: int = 8,
         confidence_thresh: float = 0.5,
+        max_inference_tiles: Optional[int] = 4096,
     ):
         if device == "auto":
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
             self.device = torch.device(device)
 
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if not 0.0 <= confidence_thresh <= 1.0:
+            raise ValueError(
+                f"confidence_thresh must be between 0 and 1, got {confidence_thresh}"
+            )
+        if max_inference_tiles is not None and max_inference_tiles < 0:
+            raise ValueError(
+                "max_inference_tiles must be non-negative or None, "
+                f"got {max_inference_tiles}"
+            )
+
         self.batch_size = batch_size
         self.confidence_thresh = confidence_thresh
+        self.max_inference_tiles = max_inference_tiles or None
         self._model = None
         self._weights_path = weights_path
         self._transform = None  # built lazily alongside the model
@@ -105,8 +123,6 @@ class NeuralTissueSegmenter:
             Binary uint8 mask of shape ``(H, W)`` where 255 = tissue and
             0 = background, at the same spatial resolution as ``img``.
         """
-        self._ensure_model_loaded()
-
         H, W = img.shape[:2]
 
         # 1. Rescale to target inference resolution (1 µm/px).
@@ -114,11 +130,27 @@ class NeuralTissueSegmenter:
         if scale != 1.0:
             target_H = max(1, int(round(H * scale)))
             target_W = max(1, int(round(W * scale)))
+        else:
+            target_H, target_W = H, W
+
+        n_tiles = _num_tiles(target_H, target_W, _INPUT_SIZE)
+        max_tiles = getattr(self, "max_inference_tiles", None)
+        if max_tiles is not None and n_tiles > max_tiles:
+            raise ValueError(
+                "Neural tissue segmentation would require "
+                f"{n_tiles:,} {_INPUT_SIZE}x{_INPUT_SIZE} inference tiles, "
+                f"which exceeds max_inference_tiles={max_tiles:,}. "
+                "Use a coarser segmentation level or set "
+                "neural_config.max_inference_tiles=0 to disable this guard."
+            )
+
+        self._ensure_model_loaded()
+
+        if scale != 1.0:
             resized = cv2.resize(
                 img, (target_W, target_H), interpolation=cv2.INTER_CUBIC
             )
         else:
-            target_H, target_W = H, W
             resized = img
 
         # 2. Tile into _INPUT_SIZE × _INPUT_SIZE patches and run inference.
@@ -220,6 +252,13 @@ class NeuralTissueSegmenter:
                 full_mask[y0:y1, x0:x1] = pred[: y1 - y0, : x1 - x0]
 
         return full_mask  # values 0 or 1
+
+
+def _num_tiles(height: int, width: int, patch_size: int) -> int:
+    """Return the number of padded inference tiles for an image."""
+    return ((height + patch_size - 1) // patch_size) * (
+        (width + patch_size - 1) // patch_size
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -12,8 +12,8 @@ import numpy as np
 import shapely
 import tiffslide
 from PIL import Image, ImageDraw
-from shapely.geometry import MultiPolygon, Polygon
-from shapely.ops import transform
+from shapely.geometry import MultiPolygon, Polygon, box
+from shapely.ops import transform, unary_union
 from shapely.prepared import prep
 
 from mussel.utils.file import save_hdf5
@@ -485,6 +485,7 @@ def _segment_tissue_neural(
     img: np.ndarray,
     slide_mpp: float,
     neural_config: Optional[dict] = None,
+    segmenter=None,
 ) -> np.ndarray:
     """Generate a binary tissue mask using Mussel's native neural segmentor.
 
@@ -514,8 +515,252 @@ def _segment_tissue_neural(
         neural_config = dict(neural_config)
     elif not isinstance(neural_config, dict):
         neural_config = vars(neural_config)
-    segmenter = NeuralTissueSegmenter(**neural_config)
+    if segmenter is None:
+        segmenter = NeuralTissueSegmenter(**neural_config)
     return segmenter.segment(img, slide_mpp=slide_mpp)
+
+
+def _neural_segmenter_from_config(neural_config: Optional[dict]):
+    """Create a neural segmenter for bounded, reusable candidate inference."""
+    from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+    config = dict(neural_config or {})
+    return NeuralTissueSegmenter(**config)
+
+
+def _axis_origins(length: int, patch_size: int, step_size: int) -> list[int]:
+    """Return valid tile origins, including the far boundary when needed."""
+    if length <= patch_size:
+        return [0]
+    last = length - patch_size
+    origins = list(range(0, last + 1, step_size))
+    if origins[-1] != last:
+        origins.append(last)
+    return origins
+
+
+def _bounded_candidate_origins(
+    proposal_mask: np.ndarray,
+    level_dimensions: tuple[int, int],
+    proposal_downsample: tuple[float, float],
+    native_patch_size: int,
+    native_step_size: int,
+    seed: int,
+) -> list[tuple[int, int]]:
+    """Find output-tile origins from a conservative thumbnail proposal.
+
+    The proposal is deliberately permissive.  It is only an I/O-saving hint;
+    the neural model makes the final tissue decision for every selected tile.
+    """
+    slide_width, slide_height = level_dimensions
+    proposal_height, proposal_width = proposal_mask.shape[:2]
+    x_origins = _axis_origins(slide_width, native_patch_size, native_step_size)
+    y_origins = _axis_origins(slide_height, native_patch_size, native_step_size)
+
+    candidates: list[tuple[int, int]] = []
+    for y in y_origins:
+        py0 = max(0, int(np.floor(y / proposal_downsample[1])))
+        py1 = min(
+            proposal_height,
+            max(py0 + 1, int(np.ceil((y + native_patch_size) / proposal_downsample[1]))),
+        )
+        for x in x_origins:
+            px0 = max(0, int(np.floor(x / proposal_downsample[0])))
+            px1 = min(
+                proposal_width,
+                max(px0 + 1, int(np.ceil((x + native_patch_size) / proposal_downsample[0]))),
+            )
+            # A one-percent threshold retains narrow tissue fragments while
+            # avoiding thousands of completely white slide tiles.
+            if float(proposal_mask[py0:py1, px0:px1].mean()) >= 0.01:
+                candidates.append((x, y))
+
+    # If the permissive thumbnail gate found nothing, retain a bounded random
+    # sample from the complete grid.  Neural inference remains the authority.
+    if not candidates:
+        candidates = [(x, y) for y in y_origins for x in x_origins]
+
+    order = np.random.default_rng(seed).permutation(len(candidates))
+    return [candidates[int(i)] for i in order]
+
+
+def _proposal_mask(img: np.ndarray) -> np.ndarray:
+    """Return a cheap, high-recall foreground proposal from an RGB thumbnail."""
+    if img.ndim == 3 and img.shape[2] > 3:
+        img = img[:, :, :3]
+    hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
+    saturation = hsv[:, :, 1]
+    value = hsv[:, :, 2]
+    # Saturation catches ordinary stains; the value branch retains pale tissue
+    # and IHC while still rejecting a clean white background.
+    proposal = ((saturation >= 5) | (value < 245)).astype(np.uint8)
+    kernel = np.ones((3, 3), dtype=np.uint8)
+    proposal = cv2.morphologyEx(proposal, cv2.MORPH_CLOSE, kernel)
+    return cv2.dilate(proposal, kernel, iterations=1)
+
+
+def _bounded_neural_tessellation(
+    *,
+    wsi,
+    proposal_img: np.ndarray,
+    slide_mpp: float,
+    level_downsamples: list[tuple[float, float]],
+    native_patch_size: int,
+    native_step_size: int,
+    patch_size: int,
+    mpp: float,
+    min_tissue_proportion: float,
+    max_tiles: int,
+    max_candidate_tiles: int,
+    max_tiles_seed: int,
+    neural_config: Optional[dict],
+    neural_segmenter=None,
+) -> tuple[MultiPolygon, list[Polygon], list[tuple[int, int]], dict] | None:
+    """Select a small number of neural-validated tiles without full-slide inference."""
+    level_dimensions = wsi.level_dimensions[0]
+    proposal_level = next(
+        i
+        for i, dimensions in enumerate(wsi.level_dimensions)
+        if dimensions == proposal_img.shape[1::-1]
+    )
+    proposal_downsample = level_downsamples[proposal_level]
+
+    proposal = _proposal_mask(proposal_img)
+    candidates = _bounded_candidate_origins(
+        proposal,
+        level_dimensions,
+        proposal_downsample,
+        native_patch_size,
+        native_step_size,
+        max_tiles_seed,
+    )
+    proposal_count = len(candidates)
+    # A thumbnail is a high-recall hint, not a hard tissue mask.  If it
+    # proposes fewer windows than the budget allows, append a deterministic
+    # sample of the remaining slide grid.  This keeps sparse or very pale
+    # slides from ending with an unnecessarily tiny sample while the neural
+    # cutoff remains authoritative.
+    if proposal_count < max_candidate_tiles:
+        x_origins = _axis_origins(
+            level_dimensions[0], native_patch_size, native_step_size
+        )
+        y_origins = _axis_origins(
+            level_dimensions[1], native_patch_size, native_step_size
+        )
+        proposed = set(candidates)
+        remaining = [
+            (x, y)
+            for y in y_origins
+            for x in x_origins
+            if (x, y) not in proposed
+        ]
+        if remaining:
+            order = np.random.default_rng(max_tiles_seed + 1).permutation(
+                len(remaining)
+            )
+            candidates.extend(remaining[int(i)] for i in order)
+
+    # Read candidate contexts at the finest available pyramid level near the
+    # neural model's 1 µm/px operating resolution.  Each context is 512 µm
+    # wide, so one model window covers the final tile plus useful surroundings.
+    target_downsample = 1.0 / slide_mpp
+    neural_level = wsi.get_best_level_for_downsample(target_downsample)
+    neural_downsample = level_downsamples[neural_level]
+    neural_level_mpp = slide_mpp * neural_downsample[0]
+    context_native_size = max(
+        native_patch_size, int(round(512.0 / slide_mpp))
+    )
+    context_level_width = max(
+        1, int(np.ceil(context_native_size / neural_downsample[0]))
+    )
+    context_level_height = max(
+        1, int(np.ceil(context_native_size / neural_downsample[1]))
+    )
+    segmenter = (
+        neural_segmenter
+        if neural_segmenter is not None
+        else _neural_segmenter_from_config(neural_config)
+    )
+    accepted: list[tuple[int, int]] = []
+    evaluated = 0
+    for batch_start in range(0, min(len(candidates), max_candidate_tiles), segmenter.batch_size):
+        candidate_batch = candidates[
+            batch_start : min(batch_start + segmenter.batch_size, max_candidate_tiles)
+        ]
+        contexts: list[np.ndarray] = []
+        mappings: list[tuple[int, int, int, int]] = []
+        for x, y in candidate_batch:
+            center_x = x + native_patch_size / 2.0
+            center_y = y + native_patch_size / 2.0
+            origin_x = int(round(center_x - context_native_size / 2.0))
+            origin_y = int(round(center_y - context_native_size / 2.0))
+            max_origin_x = max(0, int(level_dimensions[0] - context_native_size))
+            max_origin_y = max(0, int(level_dimensions[1] - context_native_size))
+            origin_x = min(max(0, origin_x), max_origin_x)
+            origin_y = min(max(0, origin_y), max_origin_y)
+            context = np.asarray(
+                wsi.read_region(
+                    (origin_x, origin_y),
+                    neural_level,
+                    (context_level_width, context_level_height),
+                )
+            )
+            if context.ndim == 3 and context.shape[2] > 3:
+                context = context[:, :, :3]
+            contexts.append(context.astype(np.uint8, copy=False))
+            tile_x = int(round((x - origin_x) / neural_downsample[0]))
+            tile_y = int(round((y - origin_y) / neural_downsample[1]))
+            tile_width = max(1, int(round(native_patch_size / neural_downsample[0])))
+            tile_height = max(1, int(round(native_patch_size / neural_downsample[1])))
+            mappings.append((tile_x, tile_y, tile_width, tile_height))
+
+        masks = segmenter.segment_patches(contexts, slide_mpp=neural_level_mpp)
+        evaluated += len(candidate_batch)
+        for (x, y), mask, (tile_x, tile_y, tile_width, tile_height) in zip(
+            candidate_batch, masks, mappings
+        ):
+            y0 = max(0, tile_y)
+            x0 = max(0, tile_x)
+            y1 = min(mask.shape[0], tile_y + tile_height)
+            x1 = min(mask.shape[1], tile_x + tile_width)
+            if y1 <= y0 or x1 <= x0:
+                fraction = 0.0
+            else:
+                fraction = float(mask[y0:y1, x0:x1].mean()) / 255.0
+            if fraction >= min_tissue_proportion:
+                accepted.append((x, y))
+                if len(accepted) >= max_tiles:
+                    break
+        if len(accepted) >= max_tiles:
+            break
+
+    if not accepted:
+        logger.warning("Bounded neural sampling found no tissue-rich tiles")
+        return None
+
+    grid = [
+        box(x, y, x + native_patch_size, y + native_patch_size)
+        for x, y in accepted
+    ]
+    polygon = unary_union(grid)
+    attrs = {
+        "selection_mode": "bounded_neural",
+        "candidate_tiles_proposed": proposal_count,
+        "candidate_tiles_evaluated": evaluated,
+        "candidate_tiles_accepted": len(accepted),
+        "max_candidate_tiles": max_candidate_tiles,
+        "neural_level": neural_level,
+        "neural_level_mpp": neural_level_mpp,
+        "tile_patch_size": patch_size,
+        "tile_mpp": mpp,
+    }
+    logger.info(
+        "Bounded neural sampling accepted %d/%d tiles after %d candidate evaluations",
+        len(accepted),
+        max_tiles,
+        evaluated,
+    )
+    return polygon, grid, accepted, attrs
 
 
 @timed
@@ -549,6 +794,9 @@ def segment_tissue(
     max_tiles: Optional[int] = None,
     max_tiles_strategy: str = "random",
     max_tiles_seed: int = 42,
+    selection_mode: str = "full_mask",
+    max_candidate_tiles: Optional[int] = None,
+    neural_segmenter=None,
 ):
     """Segment tissue regions in a whole-slide image and generate tissue patches.
 
@@ -622,6 +870,13 @@ def segment_tissue(
         max_tiles_strategy: ``"random"`` (seeded) or ``"first"`` when
             ``max_tiles`` is smaller than the available tile count.
         max_tiles_seed: Seed used by the random max-tile strategy.
+        selection_mode: ``"full_mask"`` (default) runs neural segmentation over
+            the complete slide. ``"bounded_neural"`` uses a conservative
+            thumbnail proposal and neural-validates at most
+            ``max_candidate_tiles`` candidates.
+        max_candidate_tiles: Maximum number of candidate windows evaluated by
+            bounded neural selection. Defaults to 256 in bounded mode.
+        neural_segmenter: Optional preloaded segmenter to reuse across slides.
 
     Returns:
         tuple: A 4-tuple containing:
@@ -657,6 +912,30 @@ def segment_tissue(
                 "max_tiles_strategy must be 'random' or 'first', "
                 f"got {max_tiles_strategy!r}"
             )
+        if selection_mode not in {"full_mask", "bounded_neural"}:
+            raise ValueError(
+                "selection_mode must be 'full_mask' or 'bounded_neural', "
+                f"got {selection_mode!r}"
+            )
+        if max_candidate_tiles is not None and max_candidate_tiles <= 0:
+            raise ValueError(
+                "max_candidate_tiles must be positive or None, "
+                f"got {max_candidate_tiles}"
+            )
+        if selection_mode == "bounded_neural":
+            if str(seg_model or "classic").strip().lower() != "neural":
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires seg_model='neural'"
+                )
+            if max_tiles is None or max_tiles <= 0:
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires a positive max_tiles"
+                )
+            max_candidate_tiles = max_candidate_tiles or 256
+            if max_candidate_tiles < max_tiles:
+                raise ValueError(
+                    "max_candidate_tiles must be at least max_tiles in bounded mode"
+                )
 
         if exclude_ids is None:
             exclude_ids = []
@@ -757,12 +1036,76 @@ def segment_tissue(
                 )
 
         if seg_model == "neural":
+            if selection_mode == "bounded_neural":
+                if remove_artifacts or remove_penmarks or artifact_remover_fn is not None:
+                    raise ValueError(
+                        "Artifact removal is not supported with bounded neural selection"
+                    )
+                bounded = _bounded_neural_tessellation(
+                    wsi=wsi,
+                    proposal_img=img,
+                    slide_mpp=slide_mpp,
+                    level_downsamples=level_downsamples,
+                    native_patch_size=native_patch_size,
+                    native_step_size=native_step_size,
+                    patch_size=patch_size,
+                    mpp=mpp,
+                    min_tissue_proportion=min_tissue_proportion,
+                    max_tiles=max_tiles,
+                    max_candidate_tiles=max_candidate_tiles,
+                    max_tiles_seed=max_tiles_seed,
+                    neural_config=neural_config,
+                    neural_segmenter=neural_segmenter,
+                )
+                if bounded is None:
+                    return None
+                polygon, grid, coords, bounded_attrs = bounded
+                attrs = {
+                    "seg_level": seg_level,
+                    "segment_threshold": segment_threshold,
+                    "segment_max_value": segment_max_value,
+                    "median_blur_ksize": median_blur_ksize,
+                    "morphology_ex_kernel": morphology_ex_kernel,
+                    "tissue_area_threshold": tissue_area_threshold,
+                    "hole_area_threshold": hole_area_threshold,
+                    "max_num_holes": max_num_holes,
+                    "ref_patch_size": ref_patch_size,
+                    "patch_size": native_patch_size,
+                    "step_size": native_step_size,
+                    "patch_size_to_resize_to_for_desired_mpp": patch_size,
+                    "patch_level": 0,
+                    "mpp": mpp,
+                    "native_mpp": slide_mpp,
+                    "mpp_is_fallback": mpp_is_fallback,
+                    "level_dim": wsi.level_dimensions[0],
+                    "name": slide_id,
+                    "overlap": overlap,
+                    "min_tissue_proportion": min_tissue_proportion,
+                    "seg_model": seg_model,
+                    "max_tiles": max_tiles,
+                    "max_tiles_strategy": max_tiles_strategy,
+                    "max_tiles_seed": max_tiles_seed,
+                    **bounded_attrs,
+                }
+                if output_h5_path:
+                    save_hdf5(
+                        output_h5_path,
+                        {"coords": np.array(coords, dtype=np.int64)},
+                        {"coords": attrs},
+                        mode="w",
+                    )
+                    logger.info(f"Writing to {output_h5_path}")
+                return polygon, grid, coords, attrs
+
             # The img is read at seg_level. Compute its actual MPP so that
             # NeuralTissueSegmenter can rescale to the model's 1 µm/px target.
             seg_level_ds = level_downsamples[seg_level][0]  # x-axis downsample
             seg_level_mpp = slide_mpp * seg_level_ds
             tissue_mask = _segment_tissue_neural(
-                img, seg_level_mpp, neural_config=neural_config
+                img,
+                seg_level_mpp,
+                neural_config=neural_config,
+                segmenter=neural_segmenter,
             )
         else:
             img_hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)  # Convert to HSV space
@@ -1000,6 +1343,10 @@ def segment_tissue(
             "max_tiles": -1 if max_tiles is None else max_tiles,
             "max_tiles_strategy": max_tiles_strategy,
             "max_tiles_seed": max_tiles_seed,
+            "selection_mode": selection_mode,
+            "max_candidate_tiles": (
+                -1 if max_candidate_tiles is None else max_candidate_tiles
+            ),
         }
         if output_h5_path:
             asset_dict = {"coords": np.array(coords, dtype=np.int64)}

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import multiprocessing as mp
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -480,7 +481,11 @@ def _filter_contours(
     return foreground_contours, hole_contours
 
 
-def _segment_tissue_neural(img: np.ndarray, slide_mpp: float) -> np.ndarray:
+def _segment_tissue_neural(
+    img: np.ndarray,
+    slide_mpp: float,
+    neural_config: Optional[dict] = None,
+) -> np.ndarray:
     """Generate a binary tissue mask using Mussel's native neural segmentor.
 
     Uses a DeepLabV3-ResNet50 model (pre-trained on histopathology slides) to
@@ -501,7 +506,15 @@ def _segment_tissue_neural(img: np.ndarray, slide_mpp: float) -> np.ndarray:
     """
     from mussel.utils.neural_seg import NeuralTissueSegmenter
 
-    segmenter = NeuralTissueSegmenter()
+    # Keep model/runtime controls out of the classic ``segment_tissue`` API,
+    # while allowing the CLI to pass a structured ``neural_config`` through.
+    if neural_config is None:
+        neural_config = {}
+    elif isinstance(neural_config, Mapping):
+        neural_config = dict(neural_config)
+    elif not isinstance(neural_config, dict):
+        neural_config = vars(neural_config)
+    segmenter = NeuralTissueSegmenter(**neural_config)
     return segmenter.segment(img, slide_mpp=slide_mpp)
 
 
@@ -532,6 +545,10 @@ def segment_tissue(
     artifact_remover_fn=None,  # Optional callable: (img, mask, mpp) -> mask
     seg_model: str = "classic",  # "classic" (HSV + manual threshold), "otsu" (HSV + Otsu threshold), or "neural" (DeepLabV3)
     slide_mpp_override: Optional[float] = None,
+    neural_config: Optional[dict] = None,
+    max_tiles: Optional[int] = None,
+    max_tiles_strategy: str = "random",
+    max_tiles_seed: int = 42,
 ):
     """Segment tissue regions in a whole-slide image and generate tissue patches.
 
@@ -597,6 +614,14 @@ def segment_tissue(
             ``morphology_ex_kernel`` applies to all three modes.
         slide_mpp_override: If set, use this value (µm/px) as the slide's native MPP
             instead of reading it from slide metadata.
+        neural_config: Optional model/runtime controls passed to
+            :class:`~mussel.utils.neural_seg.NeuralTissueSegmenter` when
+            ``seg_model="neural"``.
+        max_tiles: Optional maximum number of output tiles to retain after all
+            tissue filtering. ``None`` keeps all tiles.
+        max_tiles_strategy: ``"random"`` (seeded) or ``"first"`` when
+            ``max_tiles`` is smaller than the available tile count.
+        max_tiles_seed: Seed used by the random max-tile strategy.
 
     Returns:
         tuple: A 4-tuple containing:
@@ -624,6 +649,13 @@ def segment_tissue(
         if not (0.0 <= min_tissue_proportion <= 1.0):
             raise ValueError(
                 f"min_tissue_proportion must be in [0.0, 1.0], got {min_tissue_proportion}"
+            )
+        if max_tiles is not None and max_tiles <= 0:
+            raise ValueError(f"max_tiles must be positive or None, got {max_tiles}")
+        if max_tiles_strategy not in {"random", "first"}:
+            raise ValueError(
+                "max_tiles_strategy must be 'random' or 'first', "
+                f"got {max_tiles_strategy!r}"
             )
 
         if exclude_ids is None:
@@ -729,7 +761,9 @@ def segment_tissue(
             # NeuralTissueSegmenter can rescale to the model's 1 µm/px target.
             seg_level_ds = level_downsamples[seg_level][0]  # x-axis downsample
             seg_level_mpp = slide_mpp * seg_level_ds
-            tissue_mask = _segment_tissue_neural(img, seg_level_mpp)
+            tissue_mask = _segment_tissue_neural(
+                img, seg_level_mpp, neural_config=neural_config
+            )
         else:
             img_hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)  # Convert to HSV space
             img_med = cv2.medianBlur(
@@ -920,6 +954,27 @@ def segment_tissue(
                 f"{len(coords)} patches remaining"
             )
 
+        # Apply the optional output budget only after tissue and per-tile
+        # filtering, so the budget is spent on valid tiles. Preserve the
+        # partition order after random selection for stable downstream output.
+        if max_tiles is not None and len(coords) > max_tiles:
+            if max_tiles_strategy == "random":
+                selected = np.sort(
+                    np.random.default_rng(max_tiles_seed).choice(
+                        len(coords), size=max_tiles, replace=False
+                    )
+                )
+            else:
+                selected = np.arange(max_tiles)
+            grid = [grid[i] for i in selected]
+            coords = [coords[i] for i in selected]
+            logger.info(
+                "After max_tiles=%d (%s) filter: %d patches remaining",
+                max_tiles,
+                max_tiles_strategy,
+                len(coords),
+            )
+
         attrs = {
             "seg_level": seg_level,
             "segment_threshold": segment_threshold,
@@ -942,6 +997,9 @@ def segment_tissue(
             "overlap": overlap,
             "min_tissue_proportion": min_tissue_proportion,
             "seg_model": seg_model,
+            "max_tiles": -1 if max_tiles is None else max_tiles,
+            "max_tiles_strategy": max_tiles_strategy,
+            "max_tiles_seed": max_tiles_seed,
         }
         if output_h5_path:
             asset_dict = {"coords": np.array(coords, dtype=np.int64)}

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -5,7 +5,12 @@ import numpy as np
 from omegaconf import OmegaConf
 
 import mussel.cli.tessellate
-from mussel.cli.tessellate import NeuralSegConfig, SegConfig, TessellateConfig
+from mussel.cli.tessellate import (
+    NeuralSegConfig,
+    SegConfig,
+    StainSegConfig,
+    TessellateConfig,
+)
 
 # Dimensions of the test slide (85656 x 19917 at level 0)
 _SLIDE_WIDTH = 85656
@@ -107,6 +112,16 @@ def test_seg_config_max_tiles_defaults_and_overrides():
     assert cfg.max_tiles == 25
     assert cfg.max_tiles_strategy == "first"
     assert cfg.max_tiles_seed == 7
+
+
+def test_stain_seg_config_is_speed_oriented():
+    cfg = StainSegConfig()
+    assert cfg.seg_model == "neural"
+    assert cfg.selection_mode == "bounded_neural"
+    assert cfg.max_tiles == 32
+    assert cfg.max_candidate_tiles == 256
+    assert cfg.min_tissue_proportion == 0.75
+    assert cfg.tissue_area_threshold == 1
 
 
 def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -5,7 +5,7 @@ import numpy as np
 from omegaconf import OmegaConf
 
 import mussel.cli.tessellate
-from mussel.cli.tessellate import SegConfig, TessellateConfig
+from mussel.cli.tessellate import NeuralSegConfig, SegConfig, TessellateConfig
 
 # Dimensions of the test slide (85656 x 19917 at level 0)
 _SLIDE_WIDTH = 85656
@@ -86,6 +86,27 @@ def test_seg_config_seg_model_neural():
     """SegConfig accepts seg_model='neural'."""
     cfg = SegConfig(seg_model="neural")
     assert cfg.seg_model == "neural"
+
+
+def test_neural_seg_config_defaults_and_overrides():
+    cfg = NeuralSegConfig(
+        device="cpu",
+        batch_size=2,
+        confidence_thresh=0.35,
+        max_inference_tiles=100,
+    )
+    assert cfg.device == "cpu"
+    assert cfg.batch_size == 2
+    assert cfg.confidence_thresh == 0.35
+    assert cfg.max_inference_tiles == 100
+
+
+def test_seg_config_max_tiles_defaults_and_overrides():
+    assert SegConfig().max_tiles is None
+    cfg = SegConfig(max_tiles=25, max_tiles_strategy="first", max_tiles_seed=7)
+    assert cfg.max_tiles == 25
+    assert cfg.max_tiles_strategy == "first"
+    assert cfg.max_tiles_seed == 7
 
 
 def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -150,6 +150,25 @@ class TestSlideMppRescaling:
         assert mask.shape == (1024, 1024)
 
 
+class TestInferenceTileGuard:
+    def test_max_inference_tiles_raises_before_model_inference(self):
+        """Large inputs are rejected before loading/running the model."""
+        seg = _make_segmenter(_all_tissue_model())
+        seg.max_inference_tiles = 1
+        img = np.zeros((1024, 1024, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError, match="max_inference_tiles"):
+            seg.segment(img, slide_mpp=1.0)
+
+    def test_zero_max_inference_tiles_disables_guard(self):
+        from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+        seg = NeuralTissueSegmenter(
+            device="cpu", batch_size=1, max_inference_tiles=0
+        )
+        assert seg.max_inference_tiles is None
+
+
 # ---------------------------------------------------------------------------
 # _segment_tissue_neural in segment.py
 # ---------------------------------------------------------------------------
@@ -172,6 +191,31 @@ class TestSegmentTissueNeuralIntegration:
 
             result = seg_module._segment_tissue_neural(img, slide_mpp=4.0)
             mock_fn.assert_called_once_with(img, slide_mpp=4.0)
+
+    def test_neural_config_is_forwarded_to_segmenter(self):
+        from mussel.utils import segment as seg_module
+
+        fake_segmenter = MagicMock()
+        fake_segmenter.segment.return_value = np.zeros((8, 8), dtype=np.uint8)
+        config = {
+            "device": "cpu",
+            "batch_size": 2,
+            "confidence_thresh": 0.4,
+            "max_inference_tiles": 10,
+        }
+        with patch(
+            "mussel.utils.neural_seg.NeuralTissueSegmenter",
+            return_value=fake_segmenter,
+        ) as mock_cls:
+            result = seg_module._segment_tissue_neural(
+                np.zeros((8, 8, 3), dtype=np.uint8),
+                slide_mpp=1.0,
+                neural_config=config,
+            )
+
+        mock_cls.assert_called_once_with(**config)
+        fake_segmenter.segment.assert_called_once()
+        assert result.shape == (8, 8)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -119,6 +119,20 @@ class TestSegmentAllBackground:
         assert np.all(mask == 0)
 
 
+class TestSegmentPatches:
+    def test_segment_patches_preserves_each_input_shape_and_batches(self):
+        images = [
+            np.ones((128, 192, 3), dtype=np.uint8) * 200,
+            np.ones((64, 96, 3), dtype=np.uint8) * 180,
+        ]
+        seg = _make_segmenter(_all_tissue_model())
+
+        masks = seg.segment_patches(images, slide_mpp=1.0)
+
+        assert [mask.shape for mask in masks] == [(128, 192), (64, 96)]
+        assert all(np.all(mask == 255) for mask in masks)
+
+
 # ---------------------------------------------------------------------------
 # slide_mpp rescaling
 # ---------------------------------------------------------------------------

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1286,6 +1286,41 @@ class TestSegmentTissueArtifactRemover:
         )
 
 
+class TestSegmentTissueMaxTiles:
+    def test_max_tiles_caps_output_and_is_seeded(self):
+        mock_wsi = _make_mock_wsi_with_real_tissue()
+        result_a = _run_segment_with_mocks(
+            mock_wsi,
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            tissue_area_threshold=1,
+            max_tiles=3,
+            max_tiles_seed=17,
+        )
+        mock_wsi.read_region.reset_mock()
+        result_b = _run_segment_with_mocks(
+            mock_wsi,
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            tissue_area_threshold=1,
+            max_tiles=3,
+            max_tiles_seed=17,
+        )
+        assert result_a is not None and result_b is not None
+        _, _, coords_a, attrs_a = result_a
+        _, _, coords_b, _ = result_b
+        assert len(coords_a) == 3
+        assert np.array_equal(coords_a, coords_b)
+        assert attrs_a["max_tiles"] == 3
+
+    def test_max_tiles_rejects_non_positive_values(self):
+        mock_wsi = _make_mock_wsi_with_tissue()
+        with pytest.raises(ValueError, match="max_tiles"):
+            _run_segment_with_mocks(mock_wsi, max_tiles=0)
+
+
 class TestSegmentTissueSegModel:
     """Tests for the seg_model parameter in segment_tissue."""
 

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1321,6 +1321,47 @@ class TestSegmentTissueMaxTiles:
             _run_segment_with_mocks(mock_wsi, max_tiles=0)
 
 
+class TestBoundedNeuralSelection:
+    def test_bounded_neural_selects_tissue_tiles_with_candidate_cap(self):
+        mock_wsi = _make_mock_wsi_with_real_tissue(width=4096, height=4096)
+        segmenter = MagicMock()
+        segmenter.batch_size = 4
+        segmenter.segment_patches.side_effect = lambda images, slide_mpp: [
+            np.ones(image.shape[:2], dtype=np.uint8) * 255 for image in images
+        ]
+
+        result = _run_segment_with_mocks(
+            mock_wsi,
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            seg_model="neural",
+            selection_mode="bounded_neural",
+            max_tiles=3,
+            max_candidate_tiles=8,
+            min_tissue_proportion=0.75,
+            neural_segmenter=segmenter,
+        )
+
+        assert result is not None
+        _, grid, coords, attrs = result
+        assert len(coords) == 3
+        assert len(grid) == 3
+        assert attrs["selection_mode"] == "bounded_neural"
+        assert attrs["candidate_tiles_evaluated"] <= 8
+        segmenter.segment_patches.assert_called()
+
+    def test_bounded_neural_requires_neural_backend(self):
+        mock_wsi = _make_mock_wsi_with_tissue()
+        with pytest.raises(ValueError, match="requires seg_model='neural'"):
+            _run_segment_with_mocks(
+                mock_wsi,
+                selection_mode="bounded_neural",
+                max_tiles=3,
+                max_candidate_tiles=8,
+            )
+
+
 class TestSegmentTissueSegModel:
     """Tests for the seg_model parameter in segment_tissue."""
 


### PR DESCRIPTION
## What changed

Adds a speed-oriented stain classification segmentation preset and bounded neural tile selection.

- Adds `seg_config=stain` with neural segmentation, up to 32 tissue-rich tiles, a 75% minimum neural tissue fraction, and a 256-candidate budget.
- Uses a conservative thumbnail proposal followed by batched neural validation, avoiding full-slide neural mask inference.
- Reuses one neural segmenter across slides in batch tessellation workflows.
- Wires the preset into tessellation, feature extraction, and filter-tessellation CLIs.
- Documents bounded-mode behavior and adds focused tests.

## Why

Stain classification needs relatively few, mostly-tissue tiles. Full-slide neural segmentation evaluates thousands of windows unnecessarily. The bounded path caps candidate inference and stops once the requested tissue-rich sample is collected.

## Validation

- `.venv/bin/python -m compileall -q mussel`
- 110 focused tests passed; 9 slow integration tests deselected.
- On a Tesla P40, full-slide neural inference measured roughly 1,600–2,200 windows versus at most 256 in bounded mode.
