### PR TITLE
Add fast stain-oriented neural tessellation

### DIFF
--- a/README-commands.md
+++ b/README-commands.md
@@ -232,7 +232,7 @@ Neural model loading and inference are controlled independently through
 | `neural_config.device` | `"auto"` | PyTorch device (`"auto"`, `"cpu"`, `"cuda"`, or `"cuda:N"`). |
 | `neural_config.batch_size` | `8` | Number of 512×512 inference tiles per forward pass. |
 | `neural_config.confidence_thresh` | `0.5` | Tissue probability threshold (0–1). |
-| `neural_config.max_inference_tiles` | `null` (effective default `4096`) | Fail fast if one slide would require more model tiles; explicit values override `MUSSEL_NEURAL_SEG_MAX_TILES`; set to `0` to disable. |
+| `neural_config.max_inference_tiles` | `null` (effective default `4096`) | Full-mask mode fails fast if inference would exceed this limit; bounded mode treats it as an additional sampling budget and may return fewer tiles. Explicit values override `MUSSEL_NEURAL_SEG_MAX_TILES`; set to `0` to disable. |
 
 For example, cap the final HDF5 at 10,000 tiles while limiting neural inference:
 

--- a/README-commands.md
+++ b/README-commands.md
@@ -128,7 +128,7 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=stain
 | `biopsy` | Needle-core / punch biopsies | Lower area thresholds (`tissue_area_threshold=1`, `hole_area_threshold=1`) to keep small tissue cores; fewer holes (`max_num_holes=2`). | Area thresholds and `max_num_holes` still apply; `segment_threshold`/`median_blur_ksize` are ignored with a warning. |
 | `resection` | Surgical resection specimens | Stronger morphological closing (`morphology_ex_kernel=4`) to bridge gaps in large sections; same area thresholds as `default`. | Only `morphology_ex_kernel=4` has effect; `segment_threshold`/`median_blur_ksize` are ignored with a warning. Consider `default seg_config.seg_model=neural seg_config.morphology_ex_kernel=4` to avoid the warning. |
 | `tcga` | TCGA whole-slide images | Lower `segment_threshold=8` to capture pale/faded tissue; stronger closing (`morphology_ex_kernel=4`); reduced area thresholds. | `segment_threshold` is ignored with a warning (`median_blur_ksize=7` matches the default so no second warning); `morphology_ex_kernel=4` and area thresholds still apply. |
-| `stain` | Fast H&E/IHC stain classification | Neural validation, 32-tile cap, 75% minimum tissue fraction, small-region retention, and bounded candidate sampling (up to 256 candidates). | Uses the bounded neural path; it does not build a full-slide mask. |
+| `stain` | Fast H&E/IHC stain classification | Neural validation, 32-tile cap, 75% minimum tissue fraction, no contour pruning, and bounded candidate sampling (up to 256 candidates). | Uses the bounded neural path; it does not build a full-slide mask. |
 
 #### Segmentation and patching options
 
@@ -140,8 +140,8 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=stain
 | `seg_config.min_tissue_proportion` | `0.0` | Per-tile filter: discard tiles where the fraction of tissue pixels is below this value (0.0–1.0). Applied after tiling; `0.1` discards mostly-background edge tiles. |
 | `seg_config.selection_mode` | `full_mask` | `full_mask` segments the complete slide; `bounded_neural` proposes candidates cheaply and neural-validates only a bounded set. |
 | `seg_config.max_candidate_tiles` | `null` | Maximum neural candidates in `bounded_neural` mode; the `stain` preset sets this to `256`. |
-| `seg_config.tissue_area_threshold` | `100` | Pre-tile filter: minimum size of a tissue **region** (contour), in number of tiles. Regions smaller than this are discarded as debris before tiling begins. Default 100 ≈ a ~3.2 mm² blob at 256 px / 0.5 µm/px. Set to `1` to keep all regions (recommended for biopsies). |
-| `seg_config.hole_area_threshold` | `16` | Minimum size of a hole inside a tissue region, in number of tiles. Holes smaller than this are filled (treated as tissue). |
+| `seg_config.tissue_area_threshold` | `100` | Full-mask mode only: minimum size of a tissue **region** (contour), in number of tiles. Bounded neural mode performs no contour filtering. |
+| `seg_config.hole_area_threshold` | `16` | Full-mask mode only: minimum size of a hole inside a tissue region, in number of tiles. |
 | `seg_config.remove_artifacts` | `false` | Enable artifact removal (requires `artifact_remover_fn` hook). |
 | `seg_config.remove_penmarks` | `false` | Enable pen-mark removal (requires `artifact_remover_fn` hook). |
 | `seg_config.seg_model` | `"classic"` | Segmentation backend: `"classic"` (HSV + fixed threshold), `"otsu"` (HSV + Otsu automatic threshold), or `"neural"` (deep learning; see below). Note: the old `seg_config.use_otsu=true` flag is deprecated — use `seg_model=otsu` instead. |
@@ -173,7 +173,9 @@ tessellate_extract_features \
 The preset stops after 32 tiles with at least 75% neural tissue, or after 256
 candidate checks. If fewer than 32 tiles qualify, it returns the qualifying
 tiles without relaxing the cutoff. In bounded mode, mask output represents
-the accepted tile footprints rather than a complete slide tissue contour.
+the accepted tile footprints rather than a complete slide tissue contour. Contour
+ID filters are unsupported; `morphology_ex_kernel` is applied to each candidate
+mask before its tissue fraction is calculated.
 
 #### Neural tissue segmentation (`seg_model="neural"`)
 
@@ -221,7 +223,8 @@ tessellate_extract_features \
 ```
 
 Neural model loading and inference are controlled independently through
-`neural_config.*` (available on both commands):
+`neural_config.*` (available on `tessellate`, `tessellate_extract_features`, and
+`filter_tessellate`):
 
 | Parameter | Default | Description |
 |---|---|---|

--- a/README-commands.md
+++ b/README-commands.md
@@ -119,6 +119,7 @@ specimen type. Individual parameters can still be overridden after the preset:
 ```bash
 tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=biopsy
 tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config.mpp=0.25
+tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=stain
 ```
 
 | Preset | Best for | Key differences from `default` | With `seg_model=neural` |
@@ -127,6 +128,7 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `biopsy` | Needle-core / punch biopsies | Lower area thresholds (`tissue_area_threshold=1`, `hole_area_threshold=1`) to keep small tissue cores; fewer holes (`max_num_holes=2`). | Area thresholds and `max_num_holes` still apply; `segment_threshold`/`median_blur_ksize` are ignored with a warning. |
 | `resection` | Surgical resection specimens | Stronger morphological closing (`morphology_ex_kernel=4`) to bridge gaps in large sections; same area thresholds as `default`. | Only `morphology_ex_kernel=4` has effect; `segment_threshold`/`median_blur_ksize` are ignored with a warning. Consider `default seg_config.seg_model=neural seg_config.morphology_ex_kernel=4` to avoid the warning. |
 | `tcga` | TCGA whole-slide images | Lower `segment_threshold=8` to capture pale/faded tissue; stronger closing (`morphology_ex_kernel=4`); reduced area thresholds. | `segment_threshold` is ignored with a warning (`median_blur_ksize=7` matches the default so no second warning); `morphology_ex_kernel=4` and area thresholds still apply. |
+| `stain` | Fast H&E/IHC stain classification | Neural validation, 32-tile cap, 75% minimum tissue fraction, small-region retention, and bounded candidate sampling (up to 256 candidates). | Uses the bounded neural path; it does not build a full-slide mask. |
 
 #### Segmentation and patching options
 
@@ -136,6 +138,8 @@ tessellate slide_path=slide.svs output_h5_path=out.h5 seg_config=tcga seg_config
 | `seg_config.patch_size` | `256` | Tile size in pixels at the target MPP. |
 | `seg_config.overlap` | `0` | Patch overlap in absolute pixels. Sets `step_size = patch_size - overlap`. |
 | `seg_config.min_tissue_proportion` | `0.0` | Per-tile filter: discard tiles where the fraction of tissue pixels is below this value (0.0–1.0). Applied after tiling; `0.1` discards mostly-background edge tiles. |
+| `seg_config.selection_mode` | `full_mask` | `full_mask` segments the complete slide; `bounded_neural` proposes candidates cheaply and neural-validates only a bounded set. |
+| `seg_config.max_candidate_tiles` | `null` | Maximum neural candidates in `bounded_neural` mode; the `stain` preset sets this to `256`. |
 | `seg_config.tissue_area_threshold` | `100` | Pre-tile filter: minimum size of a tissue **region** (contour), in number of tiles. Regions smaller than this are discarded as debris before tiling begins. Default 100 ≈ a ~3.2 mm² blob at 256 px / 0.5 µm/px. Set to `1` to keep all regions (recommended for biopsies). |
 | `seg_config.hole_area_threshold` | `16` | Minimum size of a hole inside a tissue region, in number of tiles. Holes smaller than this are filled (treated as tissue). |
 | `seg_config.remove_artifacts` | `false` | Enable artifact removal (requires `artifact_remover_fn` hook). |
@@ -154,6 +158,22 @@ tessellate \
     seg_config.overlap=128 \
     seg_config.min_tissue_proportion=0.5
 ```
+
+For stain classification, use the speed-oriented preset:
+
+```bash
+tessellate_extract_features \
+    slide_path=slide.svs \
+    output_h5_path=slide.features.h5 \
+    output_pt_path=slide.features.pt \
+    model_type=HOPTIMUS0 \
+    seg_config=stain
+```
+
+The preset stops after 32 tiles with at least 75% neural tissue, or after 256
+candidate checks. If fewer than 32 tiles qualify, it returns the qualifying
+tiles without relaxing the cutoff. In bounded mode, mask output represents
+the accepted tile footprints rather than a complete slide tissue contour.
 
 #### Neural tissue segmentation (`seg_model="neural"`)
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Then pass `seg_config.seg_model=neural` to `tessellate` or
 performance but CPU inference is supported.
 
 Neural runtime controls are available under `neural_config.*` (weights path,
-device, batch size, confidence threshold, and `max_inference_tiles`). An explicit
+device, batch size, confidence threshold, and `max_inference_tiles`) for
+`tessellate`, `tessellate_extract_features`, and `filter_tessellate`. An explicit
 neural device takes precedence over the workflow's `use_gpu` setting; `auto`
 uses that setting. Use
 `seg_config.max_tiles` with `seg_config.max_tiles_strategy` and

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ uses that setting. Use
 `seg_config.max_tiles` with `seg_config.max_tiles_strategy` and
 `seg_config.max_tiles_seed` to cap and reproducibly sample the final output tiles.
 
+For stain classification, use `seg_config=stain`. This speed-oriented preset
+uses bounded neural validation, keeps up to 32 tiles with at least 75% tissue,
+and checks at most 256 candidates. It avoids full-slide neural inference; when
+fewer than 32 candidates qualify, it returns the qualifying tiles without
+relaxing the tissue cutoff.
+
 ## Development Notes
 
 * Any commands executed using `uv run <command...>` are automatically executed in the project environment.

--- a/README.md
+++ b/README.md
@@ -214,9 +214,10 @@ uses that setting. Use
 
 For stain classification, use `seg_config=stain`. This speed-oriented preset
 uses bounded neural validation, keeps up to 32 tiles with at least 75% tissue,
-and checks at most 256 candidates. It avoids full-slide neural inference; when
-fewer than 32 candidates qualify, it returns the qualifying tiles without
-relaxing the tissue cutoff.
+checks at most 256 candidates, and honors `neural_config.max_inference_tiles` as
+an additional inference budget. It avoids full-slide neural inference; when
+fewer than 32 candidates qualify or the inference budget is reached, it returns
+the qualifying tiles without relaxing the tissue cutoff.
 
 ## Development Notes
 

--- a/mussel/cli/filter_tessellate.py
+++ b/mussel/cli/filter_tessellate.py
@@ -16,7 +16,7 @@ from omegaconf import MISSING, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
                                    ResectionSegConfig, SegConfig,
-                                   TcgaSegConfig, VisConfig,
+                                   StainSegConfig, TcgaSegConfig, VisConfig,
                                    _build_artifact_remover)
 from mussel.cli.tessellate_extract_features_common import _build_grid_polygons
 from mussel.models import ModelType, get_default_patch_size
@@ -132,6 +132,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(name="filter_tessellate_config", node=FilterTessellateConfig)
 
 

--- a/mussel/cli/filter_tessellate.py
+++ b/mussel/cli/filter_tessellate.py
@@ -191,14 +191,21 @@ def _main(cfg: FilterTessellateConfig, temp_dir, base_path):
     # Strip config-only keys that are not segment_tissue() parameters.
     seg_cfg.pop("artifact_exclude_classes", None)
 
-    if values := segment_tissue(
-        slide_path=cfg.slide_path,
-        slide_id=cfg.slide_id,
-        output_h5_path=tessellate_h5_path,
-        artifact_remover_fn=artifact_remover_fn,
-        neural_segmenter=neural_segmenter,
-        **seg_cfg,
-    ):
+    try:
+        values = segment_tissue(
+            slide_path=cfg.slide_path,
+            slide_id=cfg.slide_id,
+            output_h5_path=tessellate_h5_path,
+            artifact_remover_fn=artifact_remover_fn,
+            neural_segmenter=neural_segmenter,
+            **seg_cfg,
+        )
+    finally:
+        release = getattr(neural_segmenter, "release", None)
+        if callable(release):
+            release()
+
+    if values:
         polygon, grid, coords, _ = values
     else:
         logger.error("Tessellation failed")

--- a/mussel/cli/filter_tessellate.py
+++ b/mussel/cli/filter_tessellate.py
@@ -15,9 +15,10 @@ from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING, OmegaConf
 
 from mussel.cli.tessellate import (BiopsySegConfig, PngConfig,
-                                   ResectionSegConfig, SegConfig,
-                                   StainSegConfig, TcgaSegConfig, VisConfig,
-                                   _build_artifact_remover)
+                                   NeuralSegConfig, ResectionSegConfig,
+                                   SegConfig, StainSegConfig, TcgaSegConfig,
+                                   VisConfig, _build_artifact_remover,
+                                   _build_neural_segmenter)
 from mussel.cli.tessellate_extract_features_common import _build_grid_polygons
 from mussel.models import ModelType, get_default_patch_size
 from mussel.utils import (filter_features, load_classifier,
@@ -47,6 +48,8 @@ class FilterTessellateConfig:
     output_thumbnail_path (Optional[str]): Path to save the thumbnail image.
     thumbnail_size (tuple): Size of the thumbnail image.
     seg_config (SegConfig): Configuration for segmentation parameters.
+    neural_config (NeuralSegConfig): Runtime controls for neural segmentation, including
+        model device and inference batch size.
     vis_config (VisConfig): Configuration for visualization parameters.
     png_config (PngConfig): Configuration for PNG saving parameters.
     num_workers (int): Number of workers for saving patches and feature extraction.
@@ -82,6 +85,7 @@ class FilterTessellateConfig:
     keep_intermediate_files: bool = False
     ssl_verify: bool = True  # Whether to verify SSL certificates for remote operations
     seg_config: SegConfig = MISSING
+    neural_config: NeuralSegConfig = field(default_factory=NeuralSegConfig)
     vis_config: VisConfig = field(default_factory=VisConfig)
     png_config: PngConfig = field(default_factory=PngConfig)
 
@@ -116,6 +120,7 @@ parameter_doc = f"""
 == Available Parameters ==
 {FilterTessellateConfig.__doc__}
 seg_config: {SegConfig.__doc__}
+neural_config: {NeuralSegConfig.__doc__}
 vis_config: {VisConfig.__doc__}
 png_config: {PngConfig.__doc__}
 
@@ -170,6 +175,19 @@ def _main(cfg: FilterTessellateConfig, temp_dir, base_path):
 
     seg_cfg = OmegaConf.to_container(cfg.seg_config)
     artifact_remover_fn = _build_artifact_remover(seg_cfg)
+    neural_cfg_obj = getattr(cfg, "neural_config", NeuralSegConfig())
+    neural_cfg = (
+        OmegaConf.to_container(neural_cfg_obj, resolve=True)
+        if OmegaConf.is_config(neural_cfg_obj)
+        else vars(neural_cfg_obj)
+    )
+    neural_segmenter = _build_neural_segmenter(
+        seg_cfg,
+        use_gpu=cfg.use_gpu,
+        gpu_device_id=cfg.gpu_device_id,
+        gpu_device_ids=cfg.gpu_device_ids,
+        neural_config=neural_cfg,
+    )
     # Strip config-only keys that are not segment_tissue() parameters.
     seg_cfg.pop("artifact_exclude_classes", None)
 
@@ -178,6 +196,7 @@ def _main(cfg: FilterTessellateConfig, temp_dir, base_path):
         slide_id=cfg.slide_id,
         output_h5_path=tessellate_h5_path,
         artifact_remover_fn=artifact_remover_fn,
+        neural_segmenter=neural_segmenter,
         **seg_cfg,
     ):
         polygon, grid, coords, _ = values

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -65,16 +65,19 @@ class SegConfig:
     ref_patch_size (int): Reference patch size (in pixels) used to scale the ``tissue_area_threshold``
         and ``hole_area_threshold`` values.
     use_otsu (bool): **Deprecated** — use ``seg_model="otsu"`` instead.
-    tissue_area_threshold (int): Minimum size of a tissue contour, expressed as the number of
-        tiles (at the configured ``patch_size`` and ``mpp``) the region must span. Contours
-        smaller than this are discarded as debris. Default 100 (≈ a ~3.2 mm² region at
-        256 px / 0.5 µm/px). Set to 1 to keep all contours (useful for biopsies).
-    hole_area_threshold (int): Minimum size of a hole inside a tissue contour, expressed as the
-        number of tiles it spans. Holes smaller than this are filled in (treated as tissue).
-        Default 16.
+    tissue_area_threshold (int): Minimum size of a tissue contour in ``full_mask`` mode,
+        expressed as the number of tiles (at the configured ``patch_size`` and ``mpp``)
+        the region must span. Contours smaller than this are discarded as debris. Default
+        100 (≈ a ~3.2 mm² region at 256 px / 0.5 µm/px). Bounded neural mode does not
+        build contours and therefore does not apply this setting.
+    hole_area_threshold (int): Minimum size of a hole inside a tissue contour in ``full_mask``
+        mode, expressed as the number of tiles it spans. Holes smaller than this are filled
+        in (treated as tissue). Bounded neural mode does not apply this setting. Default 16.
     max_num_holes (int): Maximum number of holes retained per tissue contour.
-    keep_ids (List[int]): Contour IDs to keep; all others are discarded. Empty list keeps all.
-    exclude_ids (List[int]): Contour IDs to discard. Empty list excludes none.
+    keep_ids (List[int]): Contour IDs to keep in ``full_mask`` mode; all others are discarded.
+        Empty list keeps all. Not supported in bounded neural mode.
+    exclude_ids (List[int]): Contour IDs to discard in ``full_mask`` mode. Empty list excludes
+        none. Not supported in bounded neural mode.
     min_tissue_proportion (float): Minimum fraction of tile area that must be tissue (0.0–1.0).
         Tiles below this threshold are discarded.
     remove_artifacts (bool): If True, apply artifact removal to the tissue mask before patching
@@ -160,11 +163,11 @@ class StainSegConfig(SegConfig):
     """Fast, tissue-rich preset for stain classification.
 
     The preset uses neural segmentation to validate at least 75% tissue per
-    output tile, retains small tissue regions, and stops after 32 accepted
-    tiles or 256 neural candidate evaluations.
+    output tile, performs no contour pruning so small tissue regions remain
+    eligible, and stops after 32 accepted tiles or 256 neural candidate
+    evaluations.
     """
 
-    tissue_area_threshold: int = 1
     min_tissue_proportion: float = 0.75
     seg_model: str = "neural"
     max_tiles: Optional[int] = 32

--- a/mussel/cli/tessellate.py
+++ b/mussel/cli/tessellate.py
@@ -95,6 +95,10 @@ class SegConfig:
     max_tiles_strategy (str): Sampling strategy when ``max_tiles`` is reached: ``"random"``
         (seeded, default) or ``"first"``.
     max_tiles_seed (int): Random seed used by the ``"random"`` max-tile strategy.
+    selection_mode (str): Tile selection backend: ``"full_mask"`` (default) or
+        ``"bounded_neural"`` for fast neural validation of a bounded candidate set.
+    max_candidate_tiles (Optional[int]): Candidate budget for ``bounded_neural``
+        selection. Defaults to 256 in that mode.
     artifact_remover_fn: Optional callable ``(img, mask, mpp) -> mask`` where ``img`` is the RGB
         thumbnail, ``mask`` is the binary tissue mask, and ``mpp`` is the thumbnail's µm/px.
         Returns a corrected binary mask. Use :class:`~mussel.utils.artifact_removal.GrandQCArtifactRemover`
@@ -147,6 +151,25 @@ class SegConfig:
     max_tiles: Optional[int] = None
     max_tiles_strategy: str = "random"
     max_tiles_seed: int = 42
+    selection_mode: str = "full_mask"
+    max_candidate_tiles: Optional[int] = None
+
+
+@dataclass
+class StainSegConfig(SegConfig):
+    """Fast, tissue-rich preset for stain classification.
+
+    The preset uses neural segmentation to validate at least 75% tissue per
+    output tile, retains small tissue regions, and stops after 32 accepted
+    tiles or 256 neural candidate evaluations.
+    """
+
+    tissue_area_threshold: int = 1
+    min_tissue_proportion: float = 0.75
+    seg_model: str = "neural"
+    max_tiles: Optional[int] = 32
+    selection_mode: str = "bounded_neural"
+    max_candidate_tiles: Optional[int] = 256
 
 
 @dataclass
@@ -323,7 +346,7 @@ Key options (use Hydra override syntax, e.g. seg_config.mpp=0.25):
   slide_path          Path to the slide file (required)
   output_h5_path      Path for the output HDF5 file (required)
   slide_paths         Batch mode slide paths; use output_h5_paths or output_dir for outputs
-  seg_config          Preset segmentation profile: default | biopsy | resection | tcga
+  seg_config          Preset segmentation profile: default | biopsy | resection | tcga | stain
   seg_config.mpp      Target resolution in µm/px (default 0.5 ≈ 20×; 0.25 ≈ 40×)
   seg_config.patch_size  Tile size in pixels at the target MPP (default 256)
   seg_config.seg_model   Segmentation backend: classic | otsu | neural
@@ -356,6 +379,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(name="tessellate_config", node=TessellateConfig)
 
 

--- a/mussel/cli/tessellate_extract_features.py
+++ b/mussel/cli/tessellate_extract_features.py
@@ -25,6 +25,7 @@ from mussel.cli.tessellate import (
     PngConfig,
     ResectionSegConfig,
     SegConfig,
+    StainSegConfig,
     TcgaSegConfig,
     VisConfig,
     _build_artifact_remover,
@@ -390,6 +391,7 @@ cs.store(group="seg_config", name="default", node=SegConfig)
 cs.store(group="seg_config", name="biopsy", node=BiopsySegConfig)
 cs.store(group="seg_config", name="resection", node=ResectionSegConfig)
 cs.store(group="seg_config", name="tcga", node=TcgaSegConfig)
+cs.store(group="seg_config", name="stain", node=StainSegConfig)
 cs.store(
     name="tessellate_extract_features_config", node=TessellateExtractFeaturesConfig
 )

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -168,6 +168,108 @@ class NeuralTissueSegmenter:
 
         return (full_mask * 255).astype(np.uint8)
 
+    def segment_patches(
+        self, images: list[np.ndarray], slide_mpp: float = 1.0
+    ) -> list[np.ndarray]:
+        """Segment a bounded collection of image patches in shared batches.
+
+        This is the fast-path API used by stain classification.  Unlike
+        :meth:`segment`, it never constructs a full-slide mask: each input is
+        resized to the model resolution, tiled into model windows, and
+        inferred alongside the other inputs. The returned masks have the same
+        height and width as their corresponding inputs.
+        """
+        if not images:
+            return []
+        if slide_mpp <= 0:
+            raise ValueError(f"slide_mpp must be positive, got {slide_mpp}")
+
+        self._ensure_model_loaded()
+        patch_size = _INPUT_SIZE
+        prepared: list[tuple[np.ndarray, tuple[int, int]]] = []
+        for image in images:
+            image = np.asarray(image)
+            if image.ndim != 3 or image.shape[2] < 3:
+                raise ValueError(
+                    "Each neural segmentation patch must have shape (H, W, 3+)"
+                )
+            image = image[:, :, :3].astype(np.uint8, copy=False)
+            height, width = image.shape[:2]
+            scale = slide_mpp / _TARGET_MPP
+            target_height = max(1, int(round(height * scale)))
+            target_width = max(1, int(round(width * scale)))
+            if (target_height, target_width) != (height, width):
+                image = cv2.resize(
+                    image,
+                    (target_width, target_height),
+                    interpolation=cv2.INTER_CUBIC,
+                )
+            prepared.append((image, (height, width)))
+
+        # Flatten each input into model-sized windows while retaining the
+        # originating image and window coordinates.  Batching across inputs is
+        # important here: bounded stain selection usually supplies one window
+        # per candidate context, so a single forward pass can validate many
+        # candidates at once.  Tiling also keeps this API correct if a caller
+        # supplies a context larger than one model window.
+        tile_records: list[tuple[int, int, int, int, int]] = []
+        tiles: list[np.ndarray] = []
+        output_masks = []
+        for image_index, (image, _) in enumerate(prepared):
+            target_height, target_width = image.shape[:2]
+            output_masks.append(
+                np.zeros((target_height, target_width), dtype=np.uint8)
+            )
+            for y in range(0, target_height, patch_size):
+                for x in range(0, target_width, patch_size):
+                    y1 = min(y + patch_size, target_height)
+                    x1 = min(x + patch_size, target_width)
+                    crop = image[y:y1, x:x1]
+                    if crop.shape[:2] != (patch_size, patch_size):
+                        padded = np.full(
+                            (patch_size, patch_size, 3), 255, dtype=np.uint8
+                        )
+                        padded[: crop.shape[0], : crop.shape[1]] = crop
+                        crop = padded
+                    tiles.append(crop)
+                    tile_records.append((image_index, x, y, x1, y1))
+
+        use_fp16 = self.device.type == "cuda"
+        dtype = torch.float16 if use_fp16 else torch.float32
+        for batch_start in range(0, len(tiles), self.batch_size):
+            batch = tiles[batch_start : batch_start + self.batch_size]
+            batch_np = np.stack(batch, axis=0)
+            batch_tensor = torch.from_numpy(batch_np).permute(0, 3, 1, 2)
+            batch_tensor = batch_tensor.to(self.device, dtype=dtype).div_(255.0)
+            batch_tensor = (batch_tensor - self._mean) / self._std
+            with torch.no_grad():
+                logits = self._model(batch_tensor)["out"]
+                probs = F.softmax(logits.float(), dim=1)
+                predictions = (
+                    probs[:, 1] > self.confidence_thresh
+                ).to(torch.uint8).cpu().numpy()
+
+            for prediction, record in zip(
+                predictions, tile_records[batch_start : batch_start + len(batch)]
+            ):
+                image_index, x, y, x1, y1 = record
+                output_masks[image_index][y:y1, x:x1] = prediction[
+                    : y1 - y, : x1 - x
+                ]
+
+        masks: list[np.ndarray] = []
+        for output_mask, (_, (original_height, original_width)) in zip(
+            output_masks, prepared
+        ):
+            if output_mask.shape != (original_height, original_width):
+                output_mask = cv2.resize(
+                    output_mask,
+                    (original_width, original_height),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+            masks.append((output_mask * 255).astype(np.uint8))
+        return masks
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/mussel/utils/neural_seg.py
+++ b/mussel/utils/neural_seg.py
@@ -67,7 +67,8 @@ class NeuralTissueSegmenter:
             Lower values → more tissue retained. Default 0.5.
         max_inference_tiles: Maximum number of model inference tiles for one
             slide. ``None`` uses ``MUSSEL_NEURAL_SEG_MAX_TILES`` (default 4096);
-            zero disables the guard.
+            zero disables the guard. Bounded neural selection treats this as an
+            additional sampling budget and may return fewer accepted tiles.
     """
 
     def __init__(
@@ -138,7 +139,7 @@ class NeuralTissueSegmenter:
         else:
             target_H, target_W = H, W
 
-        n_tiles = _num_tiles(target_H, target_W, _INPUT_SIZE)
+        n_tiles = _num_inference_tiles_for_shape(H, W, slide_mpp)
         if self.max_inference_tiles is not None and n_tiles > self.max_inference_tiles:
             raise ValueError(
                 "Neural tissue segmentation would require "
@@ -184,7 +185,6 @@ class NeuralTissueSegmenter:
         if slide_mpp <= 0:
             raise ValueError(f"slide_mpp must be positive, got {slide_mpp}")
 
-        self._ensure_model_loaded()
         patch_size = _INPUT_SIZE
         prepared: list[tuple[np.ndarray, tuple[int, int]]] = []
         for image in images:
@@ -234,6 +234,18 @@ class NeuralTissueSegmenter:
                     tiles.append(crop)
                     tile_records.append((image_index, x, y, x1, y1))
 
+        n_tiles = len(tiles)
+        if (
+            self.max_inference_tiles is not None
+            and n_tiles > self.max_inference_tiles
+        ):
+            raise ValueError(
+                "Neural tissue segmentation patches would require "
+                f"{n_tiles:,} {_INPUT_SIZE}x{_INPUT_SIZE} inference tiles, "
+                f"which exceeds max_inference_tiles={self.max_inference_tiles:,}."
+            )
+
+        self._ensure_model_loaded()
         use_fp16 = self.device.type == "cuda"
         dtype = torch.float16 if use_fp16 else torch.float32
         for batch_start in range(0, len(tiles), self.batch_size):
@@ -269,6 +281,20 @@ class NeuralTissueSegmenter:
                 )
             masks.append((output_mask * 255).astype(np.uint8))
         return masks
+
+    def release(self) -> None:
+        """Release model weights and CUDA allocations held by this segmenter.
+
+        The segmenter can be used again after release; weights will be loaded
+        lazily on the next inference call.
+        """
+        model = self._model
+        self._model = None
+        self._mean = None
+        self._std = None
+        del model
+        if self.device.type == "cuda":
+            torch.cuda.empty_cache()
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -376,6 +402,18 @@ def _num_tiles(height: int, width: int, patch_size: int) -> int:
     return ((height + patch_size - 1) // patch_size) * (
         (width + patch_size - 1) // patch_size
     )
+
+
+def _num_inference_tiles_for_shape(
+    height: int, width: int, slide_mpp: float
+) -> int:
+    """Return model-window count for an image shape at the given MPP."""
+    if slide_mpp <= 0:
+        raise ValueError(f"slide_mpp must be positive, got {slide_mpp}")
+    scale = slide_mpp / _TARGET_MPP
+    target_height = max(1, int(round(height * scale)))
+    target_width = max(1, int(round(width * scale)))
+    return _num_tiles(target_height, target_width, _INPUT_SIZE)
 
 
 def _get_max_inference_tiles() -> Optional[int]:

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -738,6 +738,24 @@ def _bounded_neural_tessellation(
     segmenter = neural_segmenter
     if segmenter is None:
         segmenter = _neural_segmenter_from_config(None)
+    from mussel.utils.neural_seg import _num_inference_tiles_for_shape
+
+    inference_tiles_per_candidate = _num_inference_tiles_for_shape(
+        context_level_height, context_level_width, neural_level_mpp
+    )
+    configured_inference_limit = getattr(segmenter, "max_inference_tiles", None)
+    effective_candidate_limit = max_candidate_tiles
+    if isinstance(configured_inference_limit, (int, np.integer)):
+        if configured_inference_limit < inference_tiles_per_candidate:
+            raise ValueError(
+                "max_inference_tiles is too small for one bounded neural "
+                f"candidate ({inference_tiles_per_candidate} model tiles required, "
+                f"limit is {configured_inference_limit})"
+            )
+        effective_candidate_limit = min(
+            effective_candidate_limit,
+            configured_inference_limit // inference_tiles_per_candidate,
+        )
     accepted: list[tuple[int, int]] = []
     evaluated = 0
     morphology_kernel = None
@@ -745,9 +763,13 @@ def _bounded_neural_tessellation(
         morphology_kernel = np.ones(
             (morphology_ex_kernel, morphology_ex_kernel), dtype=np.uint8
         )
-    for batch_start in range(0, min(len(candidates), max_candidate_tiles), segmenter.batch_size):
+    for batch_start in range(
+        0, min(len(candidates), effective_candidate_limit), segmenter.batch_size
+    ):
         candidate_batch = candidates[
-            batch_start : min(batch_start + segmenter.batch_size, max_candidate_tiles)
+            batch_start : min(
+                batch_start + segmenter.batch_size, effective_candidate_limit
+            )
         ]
         contexts: list[np.ndarray] = []
         mappings: list[tuple[int, int, int, int]] = []
@@ -813,6 +835,14 @@ def _bounded_neural_tessellation(
         "candidate_tiles_evaluated": evaluated,
         "candidate_tiles_accepted": len(accepted),
         "max_candidate_tiles": max_candidate_tiles,
+        "effective_candidate_tiles": effective_candidate_limit,
+        "inference_tiles_evaluated": evaluated * inference_tiles_per_candidate,
+        "max_inference_tiles": (
+            -1
+            if configured_inference_limit is None
+            or not isinstance(configured_inference_limit, (int, np.integer))
+            else configured_inference_limit
+        ),
         "neural_level": neural_level,
         "neural_level_mpp": neural_level_mpp,
         "tile_patch_size": patch_size,

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -597,6 +597,7 @@ def _bounded_candidate_origins(
     native_patch_size: int,
     native_step_size: int,
     seed: int,
+    strategy: str,
 ) -> list[tuple[int, int]]:
     """Find output-tile origins from a conservative thumbnail proposal.
 
@@ -631,8 +632,10 @@ def _bounded_candidate_origins(
     if not candidates:
         candidates = [(x, y) for y in y_origins for x in x_origins]
 
-    order = np.random.default_rng(seed).permutation(len(candidates))
-    return [candidates[int(i)] for i in order]
+    if strategy == "random":
+        order = np.random.default_rng(seed).permutation(len(candidates))
+        return [candidates[int(i)] for i in order]
+    return candidates
 
 
 def _proposal_mask(img: np.ndarray) -> np.ndarray:
@@ -663,7 +666,9 @@ def _bounded_neural_tessellation(
     min_tissue_proportion: float,
     max_tiles: int,
     max_candidate_tiles: int,
+    max_tiles_strategy: str,
     max_tiles_seed: int,
+    morphology_ex_kernel: int,
     neural_segmenter=None,
 ) -> tuple[MultiPolygon, list[Polygon], list[tuple[int, int]], dict] | None:
     """Select a small number of neural-validated tiles without full-slide inference."""
@@ -683,6 +688,7 @@ def _bounded_neural_tessellation(
         native_patch_size,
         native_step_size,
         max_tiles_seed,
+        max_tiles_strategy,
     )
     proposal_count = len(candidates)
     # A thumbnail is a high-recall hint, not a hard tissue mask.  If it
@@ -705,10 +711,13 @@ def _bounded_neural_tessellation(
             if (x, y) not in proposed
         ]
         if remaining:
-            order = np.random.default_rng(max_tiles_seed + 1).permutation(
-                len(remaining)
-            )
-            candidates.extend(remaining[int(i)] for i in order)
+            if max_tiles_strategy == "random":
+                order = np.random.default_rng(max_tiles_seed + 1).permutation(
+                    len(remaining)
+                )
+                candidates.extend(remaining[int(i)] for i in order)
+            else:
+                candidates.extend(remaining)
 
     # Read candidate contexts at the finest available pyramid level near the
     # neural model's 1 µm/px operating resolution.  Each context is 512 µm
@@ -731,6 +740,11 @@ def _bounded_neural_tessellation(
         segmenter = _neural_segmenter_from_config(None)
     accepted: list[tuple[int, int]] = []
     evaluated = 0
+    morphology_kernel = None
+    if morphology_ex_kernel > 0:
+        morphology_kernel = np.ones(
+            (morphology_ex_kernel, morphology_ex_kernel), dtype=np.uint8
+        )
     for batch_start in range(0, min(len(candidates), max_candidate_tiles), segmenter.batch_size):
         candidate_batch = candidates[
             batch_start : min(batch_start + segmenter.batch_size, max_candidate_tiles)
@@ -767,6 +781,8 @@ def _bounded_neural_tessellation(
         for (x, y), mask, (tile_x, tile_y, tile_width, tile_height) in zip(
             candidate_batch, masks, mappings
         ):
+            if morphology_kernel is not None:
+                mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, morphology_kernel)
             y0 = max(0, tile_y)
             x0 = max(0, tile_x)
             y1 = min(mask.shape[0], tile_y + tile_height)
@@ -801,6 +817,7 @@ def _bounded_neural_tessellation(
         "neural_level_mpp": neural_level_mpp,
         "tile_patch_size": patch_size,
         "tile_mpp": mpp,
+        "contour_filtering_applied": False,
     }
     logger.info(
         "Bounded neural sampling accepted %d/%d tiles after %d candidate evaluations",
@@ -968,19 +985,7 @@ def segment_tissue(
                 f"got {max_candidate_tiles}"
             )
         if selection_mode == "bounded_neural":
-            if str(seg_model or "classic").strip().lower() != "neural":
-                raise ValueError(
-                    "selection_mode='bounded_neural' requires seg_model='neural'"
-                )
-            if max_tiles is None or max_tiles <= 0:
-                raise ValueError(
-                    "selection_mode='bounded_neural' requires a positive max_tiles"
-                )
             max_candidate_tiles = max_candidate_tiles or 256
-            if max_candidate_tiles < max_tiles:
-                raise ValueError(
-                    "max_candidate_tiles must be at least max_tiles in bounded mode"
-                )
 
         if exclude_ids is None:
             exclude_ids = []
@@ -1012,6 +1017,25 @@ def segment_tissue(
                 stacklevel=2,
             )
             seg_model = "otsu"
+
+        if selection_mode == "bounded_neural":
+            if seg_model != "neural":
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires seg_model='neural'"
+                )
+            if max_tiles is None or max_tiles <= 0:
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires a positive max_tiles"
+                )
+            if max_candidate_tiles < max_tiles:
+                raise ValueError(
+                    "max_candidate_tiles must be at least max_tiles in bounded mode"
+                )
+            if keep_ids or exclude_ids:
+                raise ValueError(
+                    "contour IDs (keep_ids and exclude_ids) are not supported "
+                    "with bounded neural selection"
+                )
 
         # Get MPP with fallback handling.
         # Probe without a default first to detect whether real metadata exists.
@@ -1111,7 +1135,9 @@ def segment_tissue(
                     min_tissue_proportion=min_tissue_proportion,
                     max_tiles=max_tiles,
                     max_candidate_tiles=max_candidate_tiles,
+                    max_tiles_strategy=max_tiles_strategy,
                     max_tiles_seed=max_tiles_seed,
+                    morphology_ex_kernel=morphology_ex_kernel,
                     neural_segmenter=neural_segmenter,
                 )
                 if bounded is None:

--- a/mussel/utils/segment.py
+++ b/mussel/utils/segment.py
@@ -13,8 +13,8 @@ import numpy as np
 import shapely
 import tiffslide
 from PIL import Image, ImageDraw
-from shapely.geometry import MultiPolygon, Polygon
-from shapely.ops import transform
+from shapely.geometry import MultiPolygon, Polygon, box
+from shapely.ops import transform, unary_union
 from shapely.prepared import prep
 
 from mussel.utils.env import parse_optional_positive_env
@@ -571,6 +571,246 @@ def _segment_tissue_neural(
     return segmenter.segment(img, slide_mpp=slide_mpp)
 
 
+def _neural_segmenter_from_config(neural_config: Optional[dict]):
+    """Create a neural segmenter for bounded, reusable candidate inference."""
+    from mussel.utils.neural_seg import NeuralTissueSegmenter
+
+    config = dict(neural_config or {})
+    return NeuralTissueSegmenter(**config)
+
+
+def _axis_origins(length: int, patch_size: int, step_size: int) -> list[int]:
+    """Return valid tile origins, including the far boundary when needed."""
+    if length <= patch_size:
+        return [0]
+    last = length - patch_size
+    origins = list(range(0, last + 1, step_size))
+    if origins[-1] != last:
+        origins.append(last)
+    return origins
+
+
+def _bounded_candidate_origins(
+    proposal_mask: np.ndarray,
+    level_dimensions: tuple[int, int],
+    proposal_downsample: tuple[float, float],
+    native_patch_size: int,
+    native_step_size: int,
+    seed: int,
+) -> list[tuple[int, int]]:
+    """Find output-tile origins from a conservative thumbnail proposal.
+
+    The proposal is deliberately permissive.  It is only an I/O-saving hint;
+    the neural model makes the final tissue decision for every selected tile.
+    """
+    slide_width, slide_height = level_dimensions
+    proposal_height, proposal_width = proposal_mask.shape[:2]
+    x_origins = _axis_origins(slide_width, native_patch_size, native_step_size)
+    y_origins = _axis_origins(slide_height, native_patch_size, native_step_size)
+
+    candidates: list[tuple[int, int]] = []
+    for y in y_origins:
+        py0 = max(0, int(np.floor(y / proposal_downsample[1])))
+        py1 = min(
+            proposal_height,
+            max(py0 + 1, int(np.ceil((y + native_patch_size) / proposal_downsample[1]))),
+        )
+        for x in x_origins:
+            px0 = max(0, int(np.floor(x / proposal_downsample[0])))
+            px1 = min(
+                proposal_width,
+                max(px0 + 1, int(np.ceil((x + native_patch_size) / proposal_downsample[0]))),
+            )
+            # A one-percent threshold retains narrow tissue fragments while
+            # avoiding thousands of completely white slide tiles.
+            if float(proposal_mask[py0:py1, px0:px1].mean()) >= 0.01:
+                candidates.append((x, y))
+
+    # If the permissive thumbnail gate found nothing, retain a bounded random
+    # sample from the complete grid.  Neural inference remains the authority.
+    if not candidates:
+        candidates = [(x, y) for y in y_origins for x in x_origins]
+
+    order = np.random.default_rng(seed).permutation(len(candidates))
+    return [candidates[int(i)] for i in order]
+
+
+def _proposal_mask(img: np.ndarray) -> np.ndarray:
+    """Return a cheap, high-recall foreground proposal from an RGB thumbnail."""
+    if img.ndim == 3 and img.shape[2] > 3:
+        img = img[:, :, :3]
+    hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
+    saturation = hsv[:, :, 1]
+    value = hsv[:, :, 2]
+    # Saturation catches ordinary stains; the value branch retains pale tissue
+    # and IHC while still rejecting a clean white background.
+    proposal = ((saturation >= 5) | (value < 245)).astype(np.uint8)
+    kernel = np.ones((3, 3), dtype=np.uint8)
+    proposal = cv2.morphologyEx(proposal, cv2.MORPH_CLOSE, kernel)
+    return cv2.dilate(proposal, kernel, iterations=1)
+
+
+def _bounded_neural_tessellation(
+    *,
+    wsi,
+    proposal_img: np.ndarray,
+    slide_mpp: float,
+    level_downsamples: list[tuple[float, float]],
+    native_patch_size: int,
+    native_step_size: int,
+    patch_size: int,
+    mpp: float,
+    min_tissue_proportion: float,
+    max_tiles: int,
+    max_candidate_tiles: int,
+    max_tiles_seed: int,
+    neural_segmenter=None,
+) -> tuple[MultiPolygon, list[Polygon], list[tuple[int, int]], dict] | None:
+    """Select a small number of neural-validated tiles without full-slide inference."""
+    level_dimensions = wsi.level_dimensions[0]
+    proposal_level = next(
+        i
+        for i, dimensions in enumerate(wsi.level_dimensions)
+        if dimensions == proposal_img.shape[1::-1]
+    )
+    proposal_downsample = level_downsamples[proposal_level]
+
+    proposal = _proposal_mask(proposal_img)
+    candidates = _bounded_candidate_origins(
+        proposal,
+        level_dimensions,
+        proposal_downsample,
+        native_patch_size,
+        native_step_size,
+        max_tiles_seed,
+    )
+    proposal_count = len(candidates)
+    # A thumbnail is a high-recall hint, not a hard tissue mask.  If it
+    # proposes fewer windows than the budget allows, append a deterministic
+    # sample of the remaining slide grid.  This keeps sparse or very pale
+    # slides from ending with an unnecessarily tiny sample while the neural
+    # cutoff remains authoritative.
+    if proposal_count < max_candidate_tiles:
+        x_origins = _axis_origins(
+            level_dimensions[0], native_patch_size, native_step_size
+        )
+        y_origins = _axis_origins(
+            level_dimensions[1], native_patch_size, native_step_size
+        )
+        proposed = set(candidates)
+        remaining = [
+            (x, y)
+            for y in y_origins
+            for x in x_origins
+            if (x, y) not in proposed
+        ]
+        if remaining:
+            order = np.random.default_rng(max_tiles_seed + 1).permutation(
+                len(remaining)
+            )
+            candidates.extend(remaining[int(i)] for i in order)
+
+    # Read candidate contexts at the finest available pyramid level near the
+    # neural model's 1 µm/px operating resolution.  Each context is 512 µm
+    # wide, so one model window covers the final tile plus useful surroundings.
+    target_downsample = 1.0 / slide_mpp
+    neural_level = wsi.get_best_level_for_downsample(target_downsample)
+    neural_downsample = level_downsamples[neural_level]
+    neural_level_mpp = slide_mpp * neural_downsample[0]
+    context_native_size = max(
+        native_patch_size, int(round(512.0 / slide_mpp))
+    )
+    context_level_width = max(
+        1, int(np.ceil(context_native_size / neural_downsample[0]))
+    )
+    context_level_height = max(
+        1, int(np.ceil(context_native_size / neural_downsample[1]))
+    )
+    segmenter = neural_segmenter
+    if segmenter is None:
+        segmenter = _neural_segmenter_from_config(None)
+    accepted: list[tuple[int, int]] = []
+    evaluated = 0
+    for batch_start in range(0, min(len(candidates), max_candidate_tiles), segmenter.batch_size):
+        candidate_batch = candidates[
+            batch_start : min(batch_start + segmenter.batch_size, max_candidate_tiles)
+        ]
+        contexts: list[np.ndarray] = []
+        mappings: list[tuple[int, int, int, int]] = []
+        for x, y in candidate_batch:
+            center_x = x + native_patch_size / 2.0
+            center_y = y + native_patch_size / 2.0
+            origin_x = int(round(center_x - context_native_size / 2.0))
+            origin_y = int(round(center_y - context_native_size / 2.0))
+            max_origin_x = max(0, int(level_dimensions[0] - context_native_size))
+            max_origin_y = max(0, int(level_dimensions[1] - context_native_size))
+            origin_x = min(max(0, origin_x), max_origin_x)
+            origin_y = min(max(0, origin_y), max_origin_y)
+            context = np.asarray(
+                wsi.read_region(
+                    (origin_x, origin_y),
+                    neural_level,
+                    (context_level_width, context_level_height),
+                )
+            )
+            if context.ndim == 3 and context.shape[2] > 3:
+                context = context[:, :, :3]
+            contexts.append(context.astype(np.uint8, copy=False))
+            tile_x = int(round((x - origin_x) / neural_downsample[0]))
+            tile_y = int(round((y - origin_y) / neural_downsample[1]))
+            tile_width = max(1, int(round(native_patch_size / neural_downsample[0])))
+            tile_height = max(1, int(round(native_patch_size / neural_downsample[1])))
+            mappings.append((tile_x, tile_y, tile_width, tile_height))
+
+        masks = segmenter.segment_patches(contexts, slide_mpp=neural_level_mpp)
+        evaluated += len(candidate_batch)
+        for (x, y), mask, (tile_x, tile_y, tile_width, tile_height) in zip(
+            candidate_batch, masks, mappings
+        ):
+            y0 = max(0, tile_y)
+            x0 = max(0, tile_x)
+            y1 = min(mask.shape[0], tile_y + tile_height)
+            x1 = min(mask.shape[1], tile_x + tile_width)
+            if y1 <= y0 or x1 <= x0:
+                fraction = 0.0
+            else:
+                fraction = float(mask[y0:y1, x0:x1].mean()) / 255.0
+            if fraction >= min_tissue_proportion:
+                accepted.append((x, y))
+                if len(accepted) >= max_tiles:
+                    break
+        if len(accepted) >= max_tiles:
+            break
+
+    if not accepted:
+        logger.warning("Bounded neural sampling found no tissue-rich tiles")
+        return None
+
+    grid = [
+        box(x, y, x + native_patch_size, y + native_patch_size)
+        for x, y in accepted
+    ]
+    polygon = unary_union(grid)
+    attrs = {
+        "selection_mode": "bounded_neural",
+        "candidate_tiles_proposed": proposal_count,
+        "candidate_tiles_evaluated": evaluated,
+        "candidate_tiles_accepted": len(accepted),
+        "max_candidate_tiles": max_candidate_tiles,
+        "neural_level": neural_level,
+        "neural_level_mpp": neural_level_mpp,
+        "tile_patch_size": patch_size,
+        "tile_mpp": mpp,
+    }
+    logger.info(
+        "Bounded neural sampling accepted %d/%d tiles after %d candidate evaluations",
+        len(accepted),
+        max_tiles,
+        evaluated,
+    )
+    return polygon, grid, accepted, attrs
+
+
 @timed
 def segment_tissue(
     slide_path: str,
@@ -602,6 +842,8 @@ def segment_tissue(
     max_tiles: Optional[int] = None,
     max_tiles_strategy: str = "random",
     max_tiles_seed: int = 42,
+    selection_mode: str = "full_mask",
+    max_candidate_tiles: Optional[int] = None,
 ):
     """Segment tissue regions in a whole-slide image and generate tissue patches.
 
@@ -674,6 +916,12 @@ def segment_tissue(
         max_tiles_strategy: ``"random"`` (seeded) or ``"first"`` when ``max_tiles``
             is smaller than the available tile count.
         max_tiles_seed: Seed used by the random max-tile strategy.
+        selection_mode: ``"full_mask"`` (default) runs neural segmentation over
+            the complete slide. ``"bounded_neural"`` uses a conservative
+            thumbnail proposal and neural-validates at most
+            ``max_candidate_tiles`` candidates.
+        max_candidate_tiles: Maximum number of candidate windows evaluated by
+            bounded neural selection. Defaults to 256 in bounded mode.
 
     Returns:
         tuple: A 4-tuple containing:
@@ -709,6 +957,30 @@ def segment_tissue(
                 "max_tiles_strategy must be 'random' or 'first', "
                 f"got {max_tiles_strategy!r}"
             )
+        if selection_mode not in {"full_mask", "bounded_neural"}:
+            raise ValueError(
+                "selection_mode must be 'full_mask' or 'bounded_neural', "
+                f"got {selection_mode!r}"
+            )
+        if max_candidate_tiles is not None and max_candidate_tiles <= 0:
+            raise ValueError(
+                "max_candidate_tiles must be positive or None, "
+                f"got {max_candidate_tiles}"
+            )
+        if selection_mode == "bounded_neural":
+            if str(seg_model or "classic").strip().lower() != "neural":
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires seg_model='neural'"
+                )
+            if max_tiles is None or max_tiles <= 0:
+                raise ValueError(
+                    "selection_mode='bounded_neural' requires a positive max_tiles"
+                )
+            max_candidate_tiles = max_candidate_tiles or 256
+            if max_candidate_tiles < max_tiles:
+                raise ValueError(
+                    "max_candidate_tiles must be at least max_tiles in bounded mode"
+                )
 
         if exclude_ids is None:
             exclude_ids = []
@@ -759,7 +1031,7 @@ def segment_tissue(
         if seg_level < 0:
             if len(wsi.level_dimensions) == 1:
                 seg_level = 0
-            elif seg_model == "neural":
+            elif seg_model == "neural" and selection_mode != "bounded_neural":
                 seg_level = _get_neural_seg_level(wsi, slide_mpp, level_downsamples)
             else:
                 seg_level = wsi.get_best_level_for_downsample(64)
@@ -774,7 +1046,7 @@ def segment_tissue(
             )
             return None
 
-        if seg_model == "neural":
+        if seg_model == "neural" and selection_mode != "bounded_neural":
             seg_level_ds = level_downsamples[seg_level][0]
             seg_level_mpp = slide_mpp * seg_level_ds
             _validate_neural_seg_mpp(seg_level_mpp, seg_level)
@@ -822,6 +1094,66 @@ def segment_tissue(
                 )
 
         if seg_model == "neural":
+            if selection_mode == "bounded_neural":
+                if remove_artifacts or remove_penmarks or artifact_remover_fn is not None:
+                    raise ValueError(
+                        "Artifact removal is not supported with bounded neural selection"
+                    )
+                bounded = _bounded_neural_tessellation(
+                    wsi=wsi,
+                    proposal_img=img,
+                    slide_mpp=slide_mpp,
+                    level_downsamples=level_downsamples,
+                    native_patch_size=native_patch_size,
+                    native_step_size=native_step_size,
+                    patch_size=patch_size,
+                    mpp=mpp,
+                    min_tissue_proportion=min_tissue_proportion,
+                    max_tiles=max_tiles,
+                    max_candidate_tiles=max_candidate_tiles,
+                    max_tiles_seed=max_tiles_seed,
+                    neural_segmenter=neural_segmenter,
+                )
+                if bounded is None:
+                    return None
+                polygon, grid, coords, bounded_attrs = bounded
+                attrs = {
+                    "seg_level": seg_level,
+                    "segment_threshold": segment_threshold,
+                    "segment_max_value": segment_max_value,
+                    "median_blur_ksize": median_blur_ksize,
+                    "morphology_ex_kernel": morphology_ex_kernel,
+                    "tissue_area_threshold": tissue_area_threshold,
+                    "hole_area_threshold": hole_area_threshold,
+                    "max_num_holes": max_num_holes,
+                    "ref_patch_size": ref_patch_size,
+                    "patch_size": native_patch_size,
+                    "step_size": native_step_size,
+                    "patch_size_to_resize_to_for_desired_mpp": patch_size,
+                    "patch_level": 0,
+                    "mpp": mpp,
+                    "native_mpp": slide_mpp,
+                    "mpp_is_fallback": mpp_is_fallback,
+                    "level_dim": wsi.level_dimensions[0],
+                    "name": slide_id,
+                    "overlap": overlap,
+                    "min_tissue_proportion": min_tissue_proportion,
+                    "seg_model": seg_model,
+                    "max_tiles": max_tiles,
+                    "max_tiles_strategy": max_tiles_strategy,
+                    "max_tiles_seed": max_tiles_seed,
+                    **bounded_attrs,
+                }
+                if output_h5_path:
+                    save_hdf5(
+                        output_h5_path,
+                        {"coords": np.array(coords, dtype=np.int64)},
+                        {"coords": attrs},
+                        mode="w",
+                    )
+                    logger.info(f"Writing to {output_h5_path}")
+                return polygon, grid, coords, attrs
+
             # The img is read at seg_level. Compute its actual MPP so that
             # NeuralTissueSegmenter can rescale to the model's 1 µm/px target.
             tissue_mask = _segment_tissue_neural(
@@ -1069,6 +1401,10 @@ def segment_tissue(
             "max_tiles": -1 if max_tiles is None else max_tiles,
             "max_tiles_strategy": max_tiles_strategy,
             "max_tiles_seed": max_tiles_seed,
+            "selection_mode": selection_mode,
+            "max_candidate_tiles": (
+                -1 if max_candidate_tiles is None else max_candidate_tiles
+            ),
         }
         if output_h5_path:
             asset_dict = {"coords": np.array(coords, dtype=np.int64)}

--- a/tests/mussel/cli/test_filter_tessellate.py
+++ b/tests/mussel/cli/test_filter_tessellate.py
@@ -89,6 +89,7 @@ def test_filter_tessellate_forwards_reusable_neural_segmenter(tmp_path):
     build_segmenter.assert_called_once()
     assert build_segmenter.call_args.kwargs["neural_config"]["batch_size"] == 32
     assert segment.call_args.kwargs["neural_segmenter"] is shared_segmenter
+    shared_segmenter.release.assert_called_once()
 
 
 @pytest.mark.slow

--- a/tests/mussel/cli/test_filter_tessellate.py
+++ b/tests/mussel/cli/test_filter_tessellate.py
@@ -1,10 +1,12 @@
 import os
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from omegaconf import OmegaConf
 
 from mussel.cli.filter_tessellate import FilterTessellateConfig
-from mussel.cli.tessellate import SegConfig
+from mussel.cli.tessellate import NeuralSegConfig, SegConfig, StainSegConfig
 from mussel.models import ModelType
 
 _FILTER_TESSELLATE_REQUIRED = dict(
@@ -44,6 +46,49 @@ def test_filter_tessellate_explicit_patch_size_preserved():
         seg_config=SegConfig(patch_size=384),
     )
     assert cfg.seg_config.patch_size == 384
+
+
+def test_filter_tessellate_exposes_neural_runtime_config():
+    cfg = FilterTessellateConfig(
+        **_FILTER_TESSELLATE_REQUIRED,
+        seg_config=StainSegConfig(),
+        neural_config=NeuralSegConfig(batch_size=32, device="cpu"),
+    )
+
+    assert cfg.neural_config.batch_size == 32
+    assert cfg.neural_config.device == "cpu"
+
+
+def test_filter_tessellate_forwards_reusable_neural_segmenter(tmp_path):
+    cfg = OmegaConf.create(
+        FilterTessellateConfig(
+            **_FILTER_TESSELLATE_REQUIRED,
+            seg_config=StainSegConfig(),
+            neural_config=NeuralSegConfig(batch_size=32, device="cpu"),
+            use_gpu=False,
+        )
+    )
+    shared_segmenter = MagicMock()
+
+    with (
+        patch(
+            "mussel.cli.filter_tessellate._build_neural_segmenter",
+            return_value=shared_segmenter,
+        ) as build_segmenter,
+        patch(
+            "mussel.cli.filter_tessellate._build_artifact_remover", return_value=None
+        ),
+        patch(
+            "mussel.cli.filter_tessellate.segment_tissue", return_value=None
+        ) as segment,
+    ):
+        from mussel.cli.filter_tessellate import _main
+
+        _main(cfg, str(tmp_path), tmp_path)
+
+    build_segmenter.assert_called_once()
+    assert build_segmenter.call_args.kwargs["neural_config"]["batch_size"] == 32
+    assert segment.call_args.kwargs["neural_segmenter"] is shared_segmenter
 
 
 @pytest.mark.slow

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -323,7 +323,6 @@ def test_stain_seg_config_is_speed_oriented():
     assert cfg.max_tiles == 32
     assert cfg.max_candidate_tiles == 256
     assert cfg.min_tissue_proportion == 0.75
-    assert cfg.tissue_area_threshold == 1
 
 def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
     """_tessellate_and_filter instantiates GrandQCArtifactRemover when remove_artifacts=True.

--- a/tests/mussel/cli/test_tessellate.py
+++ b/tests/mussel/cli/test_tessellate.py
@@ -8,7 +8,12 @@ import pytest
 from omegaconf import OmegaConf
 
 import mussel.cli.tessellate
-from mussel.cli.tessellate import NeuralSegConfig, SegConfig, TessellateConfig
+from mussel.cli.tessellate import (
+    NeuralSegConfig,
+    SegConfig,
+    StainSegConfig,
+    TessellateConfig,
+)
 
 # Dimensions of the test slide (85656 x 19917 at level 0)
 _SLIDE_WIDTH = 85656
@@ -310,6 +315,15 @@ def test_seg_config_seg_model_neural():
     cfg = SegConfig(seg_model="neural")
     assert cfg.seg_model == "neural"
 
+
+def test_stain_seg_config_is_speed_oriented():
+    cfg = StainSegConfig()
+    assert cfg.seg_model == "neural"
+    assert cfg.selection_mode == "bounded_neural"
+    assert cfg.max_tiles == 32
+    assert cfg.max_candidate_tiles == 256
+    assert cfg.min_tissue_proportion == 0.75
+    assert cfg.tissue_area_threshold == 1
 
 def test_artifact_remover_fn_wired_when_remove_artifacts(tmp_path):
     """_tessellate_and_filter instantiates GrandQCArtifactRemover when remove_artifacts=True.

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -134,6 +134,29 @@ class TestSegmentPatches:
         assert [mask.shape for mask in masks] == [(128, 192), (64, 96)]
         assert all(np.all(mask == 255) for mask in masks)
 
+    def test_segment_patches_enforces_inference_tile_guard_before_loading(self):
+        images = [
+            np.ones((512, 512, 3), dtype=np.uint8) * 200,
+            np.ones((512, 512, 3), dtype=np.uint8) * 180,
+        ]
+        seg = _make_segmenter(_all_tissue_model())
+        seg.max_inference_tiles = 1
+
+        with patch.object(seg, "_ensure_model_loaded") as mock_load:
+            with pytest.raises(ValueError, match="max_inference_tiles"):
+                seg.segment_patches(images, slide_mpp=1.0)
+
+        mock_load.assert_not_called()
+
+    def test_release_drops_loaded_model_and_normalization_tensors(self):
+        seg = _make_segmenter(_all_tissue_model())
+
+        seg.release()
+
+        assert seg._model is None
+        assert seg._mean is None
+        assert seg._std is None
+
 
 # ---------------------------------------------------------------------------
 # slide_mpp rescaling

--- a/tests/mussel/utils/test_neural_seg.py
+++ b/tests/mussel/utils/test_neural_seg.py
@@ -121,6 +121,20 @@ class TestSegmentAllBackground:
         assert np.all(mask == 0)
 
 
+class TestSegmentPatches:
+    def test_segment_patches_preserves_each_input_shape_and_batches(self):
+        images = [
+            np.ones((128, 192, 3), dtype=np.uint8) * 200,
+            np.ones((64, 96, 3), dtype=np.uint8) * 180,
+        ]
+        seg = _make_segmenter(_all_tissue_model())
+
+        masks = seg.segment_patches(images, slide_mpp=1.0)
+
+        assert [mask.shape for mask in masks] == [(128, 192), (64, 96)]
+        assert all(np.all(mask == 255) for mask in masks)
+
+
 # ---------------------------------------------------------------------------
 # slide_mpp rescaling
 # ---------------------------------------------------------------------------

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1398,6 +1398,34 @@ class TestBoundedNeuralSelection:
         assert attrs["candidate_tiles_evaluated"] <= 8
         segmenter.segment_patches.assert_called()
 
+    def test_bounded_neural_applies_inference_tile_budget(self):
+        mock_wsi = _make_mock_wsi_with_real_tissue(width=4096, height=4096)
+        segmenter = MagicMock()
+        segmenter.batch_size = 4
+        segmenter.max_inference_tiles = 2
+        segmenter.segment_patches.side_effect = lambda images, slide_mpp: [
+            np.ones(image.shape[:2], dtype=np.uint8) * 255 for image in images
+        ]
+
+        result = _run_segment_with_mocks(
+            mock_wsi,
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            seg_model="neural",
+            selection_mode="bounded_neural",
+            max_tiles=3,
+            max_candidate_tiles=8,
+            min_tissue_proportion=0.75,
+            neural_segmenter=segmenter,
+        )
+
+        assert result is not None
+        _, _, coords, attrs = result
+        assert len(coords) == 2
+        assert attrs["effective_candidate_tiles"] == 2
+        assert attrs["inference_tiles_evaluated"] == 2
+
     def test_bounded_neural_requires_neural_backend(self):
         mock_wsi = _make_mock_wsi_with_tissue()
         with pytest.raises(ValueError, match="requires seg_model='neural'"):

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1347,6 +1347,28 @@ class TestSegmentTissueArtifactRemover:
 
 
 class TestBoundedNeuralSelection:
+    def test_bounded_neural_honors_first_candidate_order(self):
+        from mussel.utils.segment import _bounded_candidate_origins
+
+        proposal = np.ones((256, 256), dtype=np.uint8)
+        origins = _bounded_candidate_origins(
+            proposal,
+            (1024, 1024),
+            (4.0, 4.0),
+            native_patch_size=256,
+            native_step_size=256,
+            seed=42,
+            strategy="first",
+        )
+
+        assert origins[:5] == [
+            (0, 0),
+            (256, 0),
+            (512, 0),
+            (768, 0),
+            (0, 256),
+        ]
+
     def test_bounded_neural_selects_tissue_tiles_with_candidate_cap(self):
         mock_wsi = _make_mock_wsi_with_real_tissue(width=4096, height=4096)
         segmenter = MagicMock()
@@ -1384,6 +1406,28 @@ class TestBoundedNeuralSelection:
                 selection_mode="bounded_neural",
                 max_tiles=3,
                 max_candidate_tiles=8,
+            )
+
+    def test_bounded_neural_rejects_deprecated_otsu_override(self):
+        with pytest.raises(ValueError, match="requires seg_model='neural'"):
+            _run_segment_with_mocks(
+                _make_mock_wsi_with_tissue(),
+                seg_model="neural",
+                use_otsu=True,
+                selection_mode="bounded_neural",
+                max_tiles=3,
+                max_candidate_tiles=8,
+            )
+
+    def test_bounded_neural_rejects_contour_id_filters(self):
+        with pytest.raises(ValueError, match="contour IDs"):
+            _run_segment_with_mocks(
+                _make_mock_wsi_with_tissue(),
+                seg_model="neural",
+                selection_mode="bounded_neural",
+                max_tiles=3,
+                max_candidate_tiles=8,
+                keep_ids=[0],
             )
 
 

--- a/tests/mussel/utils/test_segment.py
+++ b/tests/mussel/utils/test_segment.py
@@ -1346,6 +1346,47 @@ class TestSegmentTissueArtifactRemover:
         ), "Should use seg-level thumbnail when mpp is within limit"
 
 
+class TestBoundedNeuralSelection:
+    def test_bounded_neural_selects_tissue_tiles_with_candidate_cap(self):
+        mock_wsi = _make_mock_wsi_with_real_tissue(width=4096, height=4096)
+        segmenter = MagicMock()
+        segmenter.batch_size = 4
+        segmenter.segment_patches.side_effect = lambda images, slide_mpp: [
+            np.ones(image.shape[:2], dtype=np.uint8) * 255 for image in images
+        ]
+
+        result = _run_segment_with_mocks(
+            mock_wsi,
+            seg_level=1,
+            patch_size=256,
+            mpp=0.5,
+            seg_model="neural",
+            selection_mode="bounded_neural",
+            max_tiles=3,
+            max_candidate_tiles=8,
+            min_tissue_proportion=0.75,
+            neural_segmenter=segmenter,
+        )
+
+        assert result is not None
+        _, grid, coords, attrs = result
+        assert len(coords) == 3
+        assert len(grid) == 3
+        assert attrs["selection_mode"] == "bounded_neural"
+        assert attrs["candidate_tiles_evaluated"] <= 8
+        segmenter.segment_patches.assert_called()
+
+    def test_bounded_neural_requires_neural_backend(self):
+        mock_wsi = _make_mock_wsi_with_tissue()
+        with pytest.raises(ValueError, match="requires seg_model='neural'"):
+            _run_segment_with_mocks(
+                mock_wsi,
+                selection_mode="bounded_neural",
+                max_tiles=3,
+                max_candidate_tiles=8,
+            )
+
+
 class TestSegmentTissueSegModel:
     """Tests for the seg_model parameter in segment_tissue."""
 


### PR DESCRIPTION
## What changed

Adds a speed-oriented stain classification segmentation preset and bounded neural tile selection.

- Adds `seg_config=stain` with neural segmentation, up to 32 tissue-rich tiles, a 75% minimum neural tissue fraction, and a 256-candidate budget.
- Uses a conservative thumbnail proposal followed by batched neural validation, avoiding full-slide neural mask inference.
- Reuses one neural segmenter across slides in batch tessellation workflows.
- Exposes `neural_config.*` in `tessellate`, `tessellate_extract_features`, and `filter_tessellate`, including configurable neural batch size and device.
- Honors bounded `max_tiles_strategy`, applies morphology to candidate masks, and rejects unsupported contour-ID filters and conflicting deprecated Otsu mode.
- Enforces `max_inference_tiles` across bounded batches and releases the neural model before classifier feature extraction.
- Wires the preset into tessellation, feature extraction, and filter-tessellation CLIs.
- Documents bounded-mode behavior and adds focused tests.

## Why

Stain classification needs relatively few, mostly-tissue tiles. Full-slide neural segmentation evaluates thousands of windows unnecessarily. The bounded path caps candidate inference and stops once the requested tissue-rich sample is collected.

## Validation

- `python -m compileall -q mussel tests`
- 138 focused segmentation/CLI/neural tests passed; 8 slow tests deselected.
- `git diff --check` passed.
- On a Tesla P40, full-slide neural inference measured roughly 1,600–2,200 windows versus at most 256 in bounded mode.
